### PR TITLE
Users can't review declined bookings, they can remove them

### DIFF
--- a/booking/templates/booking/my_bookings.html
+++ b/booking/templates/booking/my_bookings.html
@@ -25,8 +25,10 @@
           {% if booking.is_reviewed %}
             <span class="badge bg-success">Reviewed</span>
           {% else %}
-            {% if booking.has_started %}
+            {% if booking.can_be_reviewed %}
               <a href="{% url 'review_booking' booking.id %}" class="btn btn-primary btn-sm mt-2">Review</a>
+            {% elif booking.status == "DECLINED" %}
+              <a href="{% url 'cancel_booking' booking.id %}" class="btn btn-danger btn-sm mt-2">Remove</a>
             {% else %}
               <a href="{% url 'cancel_booking' booking.id %}" class="btn btn-danger btn-sm mt-2">Cancel</a>
             {% endif %}

--- a/booking/views.py
+++ b/booking/views.py
@@ -135,5 +135,6 @@ def my_bookings(request):
         now_naive = datetime.now()
         booking.has_started = now_naive >= booking_datetime
         booking.is_reviewed = hasattr(booking, "review")
+        booking.can_be_reviewed = booking.has_started and booking.status != "DECLINED"
 
     return render(request, "booking/my_bookings.html", {"bookings": user_bookings})


### PR DESCRIPTION
If a booking is declined, the user will now have the option to leave it on their bookings page or remove it. They can no longer review the booking.

I believe the tests in booking_views already cover this, but let me know if not.