### PR TITLE
Calendar restrictions

### DIFF
--- a/booking/forms.py
+++ b/booking/forms.py
@@ -30,8 +30,16 @@ class BookingSlotForm(forms.ModelForm):
         model = BookingSlot
         fields = ["start_date", "start_time", "end_date", "end_time"]
         widgets = {
-            "start_date": forms.DateInput(attrs={"type": "date",}),
-            "end_date": forms.DateInput(attrs={"type": "date",}),
+            "start_date": forms.DateInput(
+                attrs={
+                    "type": "date",
+                }
+            ),
+            "end_date": forms.DateInput(
+                attrs={
+                    "type": "date",
+                }
+            ),
         }
 
     def __init__(self, *args, **kwargs):
@@ -40,23 +48,27 @@ class BookingSlotForm(forms.ModelForm):
         super().__init__(*args, **kwargs)
 
         # Set min date to today for start_date and end_date fields.
-        if self.listing and hasattr(self.listing, 'earliest_start_datetime'):
+        if self.listing and hasattr(self.listing, "earliest_start_datetime"):
             earliest_date = self.listing.earliest_start_datetime
             if earliest_date:
                 min_date_str = earliest_date.date().strftime("%Y-%m-%d")
-                min_date_str = min_date_str if min_date_str >= dt.date.today().strftime("%Y-%m-%d") else dt.date.today().strftime("%Y-%m-%d")
-                self.fields['start_date'].widget.attrs['min'] = min_date_str
-                self.fields['end_date'].widget.attrs['min'] = min_date_str
-        
-        # Set max date based on listing's latest end date        
-        if self.listing and hasattr(self.listing, 'latest_end_datetime'):
+                min_date_str = (
+                    min_date_str
+                    if min_date_str >= dt.date.today().strftime("%Y-%m-%d")
+                    else dt.date.today().strftime("%Y-%m-%d")
+                )
+                self.fields["start_date"].widget.attrs["min"] = min_date_str
+                self.fields["end_date"].widget.attrs["min"] = min_date_str
+
+        # Set max date based on listing's latest end date
+        if self.listing and hasattr(self.listing, "latest_end_datetime"):
             latest_date = self.listing.latest_end_datetime
-    
+
             if latest_date:
                 max_date_str = latest_date.date().strftime("%Y-%m-%d")
-                self.fields['start_date'].widget.attrs['max'] = max_date_str
-                self.fields['end_date'].widget.attrs['max'] = max_date_str
-        
+                self.fields["start_date"].widget.attrs["max"] = max_date_str
+                self.fields["end_date"].widget.attrs["max"] = max_date_str
+
         # If a start date exists, filter the time choices based on the listing's slots.
         start_date_str = self.data.get("start_date") or self.initial.get("start_date")
         if start_date_str and self.listing:

--- a/booking/forms.py
+++ b/booking/forms.py
@@ -30,14 +30,33 @@ class BookingSlotForm(forms.ModelForm):
         model = BookingSlot
         fields = ["start_date", "start_time", "end_date", "end_time"]
         widgets = {
-            "start_date": forms.DateInput(attrs={"type": "date"}),
-            "end_date": forms.DateInput(attrs={"type": "date"}),
+            "start_date": forms.DateInput(attrs={"type": "date",}),
+            "end_date": forms.DateInput(attrs={"type": "date",}),
         }
 
     def __init__(self, *args, **kwargs):
         # Pop 'listing' if provided; then store it for later use.
         self.listing = kwargs.pop("listing", None)
         super().__init__(*args, **kwargs)
+
+        # Set min date to today for start_date and end_date fields.
+        if self.listing and hasattr(self.listing, 'earliest_start_datetime'):
+            earliest_date = self.listing.earliest_start_datetime
+            if earliest_date:
+                min_date_str = earliest_date.date().strftime("%Y-%m-%d")
+                min_date_str = min_date_str if min_date_str >= dt.date.today().strftime("%Y-%m-%d") else dt.date.today().strftime("%Y-%m-%d")
+                self.fields['start_date'].widget.attrs['min'] = min_date_str
+                self.fields['end_date'].widget.attrs['min'] = min_date_str
+        
+        # Set max date based on listing's latest end date        
+        if self.listing and hasattr(self.listing, 'latest_end_datetime'):
+            latest_date = self.listing.latest_end_datetime
+    
+            if latest_date:
+                max_date_str = latest_date.date().strftime("%Y-%m-%d")
+                self.fields['start_date'].widget.attrs['max'] = max_date_str
+                self.fields['end_date'].widget.attrs['max'] = max_date_str
+        
         # If a start date exists, filter the time choices based on the listing's slots.
         start_date_str = self.data.get("start_date") or self.initial.get("start_date")
         if start_date_str and self.listing:

--- a/booking/tests/test_forms.py
+++ b/booking/tests/test_forms.py
@@ -1,45 +1,47 @@
 import datetime as dt
 from django.test import TestCase
 from booking.forms import BookingSlotForm
-from booking.models import Listing, BookingSlot
-from listings.models import Listing
+from booking.models import Listing
 from django.contrib.auth.models import User
+
 
 class BookingSlotFormTests(TestCase):
     def setUp(self):
         # Create a user first
         self.user = User.objects.create_user(username="testuser", password="password")
-        
+
         # Create a listing with real fields
         self.listing = Listing.objects.create(
             user=self.user,
             title="Test Listing",
             location="Test Location",
             rent_per_hour=10.0,
-            description="Test description"
+            description="Test description",
         )
-        
+
         # Create listing slots that will determine the earliest/latest dates
         from listings.models import ListingSlot
+
         ListingSlot.objects.create(
             listing=self.listing,
             start_date=dt.date(2023, 1, 1),
             end_date=dt.date(2023, 12, 31),
             start_time=dt.time(8, 0),
-            end_time=dt.time(18, 0)
+            end_time=dt.time(18, 0),
         )
 
     def test_min_date_set_to_today_if_earliest_start_date_is_past(self):
         form = BookingSlotForm(listing=self.listing)
         today_str = dt.date.today().strftime("%Y-%m-%d")
-        self.assertEqual(form.fields['start_date'].widget.attrs['min'], today_str)
-        self.assertEqual(form.fields['end_date'].widget.attrs['min'], today_str)
+        self.assertEqual(form.fields["start_date"].widget.attrs["min"], today_str)
+        self.assertEqual(form.fields["end_date"].widget.attrs["min"], today_str)
 
     def test_min_date_set_to_earliest_start_date_if_future(self):
         # Delete existing slot
         from listings.models import ListingSlot
+
         ListingSlot.objects.filter(listing=self.listing).delete()
-        
+
         # Create a new slot with future dates
         future_date = dt.date.today() + dt.timedelta(days=10)
         ListingSlot.objects.create(
@@ -47,30 +49,30 @@ class BookingSlotFormTests(TestCase):
             start_date=future_date,
             end_date=future_date + dt.timedelta(days=30),
             start_time=dt.time(8, 0),
-            end_time=dt.time(18, 0)
+            end_time=dt.time(18, 0),
         )
-        
+
         # Now the property will return the future date
         form = BookingSlotForm(listing=self.listing)
         future_date_str = future_date.strftime("%Y-%m-%d")
-        self.assertEqual(form.fields['start_date'].widget.attrs['min'], future_date_str)
-        self.assertEqual(form.fields['end_date'].widget.attrs['min'], future_date_str)
+        self.assertEqual(form.fields["start_date"].widget.attrs["min"], future_date_str)
+        self.assertEqual(form.fields["end_date"].widget.attrs["min"], future_date_str)
 
     def test_max_date_set_to_latest_end_date(self):
         form = BookingSlotForm(listing=self.listing)
         latest_date_str = self.listing.latest_end_datetime.date().strftime("%Y-%m-%d")
-        self.assertEqual(form.fields['start_date'].widget.attrs['max'], latest_date_str)
-        self.assertEqual(form.fields['end_date'].widget.attrs['max'], latest_date_str)
+        self.assertEqual(form.fields["start_date"].widget.attrs["max"], latest_date_str)
+        self.assertEqual(form.fields["end_date"].widget.attrs["max"], latest_date_str)
 
     def test_time_choices_filtered_based_on_listing_slots(self):
-        form_data = {'start_date': '2023-01-01'}
+        form_data = {"start_date": "2023-01-01"}
         form = BookingSlotForm(data=form_data, listing=self.listing)
-        
+
         # Create expected choices with half-hour increments
         expected_choices = []
         for hour in range(8, 18):  # Changed from 18 to 17 to exclude 17:30
             expected_choices.append((f"{hour:02d}:00", f"{hour:02d}:00"))
             expected_choices.append((f"{hour:02d}:30", f"{hour:02d}:30"))
-        
-        self.assertEqual(form.fields['start_time'].choices, expected_choices)
-        self.assertEqual(form.fields['end_time'].choices, expected_choices)
+
+        self.assertEqual(form.fields["start_time"].choices, expected_choices)
+        self.assertEqual(form.fields["end_time"].choices, expected_choices)

--- a/booking/tests/test_forms.py
+++ b/booking/tests/test_forms.py
@@ -1,0 +1,76 @@
+import datetime as dt
+from django.test import TestCase
+from booking.forms import BookingSlotForm
+from booking.models import Listing, BookingSlot
+from listings.models import Listing
+from django.contrib.auth.models import User
+
+class BookingSlotFormTests(TestCase):
+    def setUp(self):
+        # Create a user first
+        self.user = User.objects.create_user(username="testuser", password="password")
+        
+        # Create a listing with real fields
+        self.listing = Listing.objects.create(
+            user=self.user,
+            title="Test Listing",
+            location="Test Location",
+            rent_per_hour=10.0,
+            description="Test description"
+        )
+        
+        # Create listing slots that will determine the earliest/latest dates
+        from listings.models import ListingSlot
+        ListingSlot.objects.create(
+            listing=self.listing,
+            start_date=dt.date(2023, 1, 1),
+            end_date=dt.date(2023, 12, 31),
+            start_time=dt.time(8, 0),
+            end_time=dt.time(18, 0)
+        )
+
+    def test_min_date_set_to_today_if_earliest_start_date_is_past(self):
+        form = BookingSlotForm(listing=self.listing)
+        today_str = dt.date.today().strftime("%Y-%m-%d")
+        self.assertEqual(form.fields['start_date'].widget.attrs['min'], today_str)
+        self.assertEqual(form.fields['end_date'].widget.attrs['min'], today_str)
+
+    def test_min_date_set_to_earliest_start_date_if_future(self):
+        # Delete existing slot
+        from listings.models import ListingSlot
+        ListingSlot.objects.filter(listing=self.listing).delete()
+        
+        # Create a new slot with future dates
+        future_date = dt.date.today() + dt.timedelta(days=10)
+        ListingSlot.objects.create(
+            listing=self.listing,
+            start_date=future_date,
+            end_date=future_date + dt.timedelta(days=30),
+            start_time=dt.time(8, 0),
+            end_time=dt.time(18, 0)
+        )
+        
+        # Now the property will return the future date
+        form = BookingSlotForm(listing=self.listing)
+        future_date_str = future_date.strftime("%Y-%m-%d")
+        self.assertEqual(form.fields['start_date'].widget.attrs['min'], future_date_str)
+        self.assertEqual(form.fields['end_date'].widget.attrs['min'], future_date_str)
+
+    def test_max_date_set_to_latest_end_date(self):
+        form = BookingSlotForm(listing=self.listing)
+        latest_date_str = self.listing.latest_end_datetime.date().strftime("%Y-%m-%d")
+        self.assertEqual(form.fields['start_date'].widget.attrs['max'], latest_date_str)
+        self.assertEqual(form.fields['end_date'].widget.attrs['max'], latest_date_str)
+
+    def test_time_choices_filtered_based_on_listing_slots(self):
+        form_data = {'start_date': '2023-01-01'}
+        form = BookingSlotForm(data=form_data, listing=self.listing)
+        
+        # Create expected choices with half-hour increments
+        expected_choices = []
+        for hour in range(8, 18):  # Changed from 18 to 17 to exclude 17:30
+            expected_choices.append((f"{hour:02d}:00", f"{hour:02d}:00"))
+            expected_choices.append((f"{hour:02d}:30", f"{hour:02d}:30"))
+        
+        self.assertEqual(form.fields['start_time'].choices, expected_choices)
+        self.assertEqual(form.fields['end_time'].choices, expected_choices)

--- a/booking/views.py
+++ b/booking/views.py
@@ -97,7 +97,9 @@ def book_listing(request, listing_id):
 
     if request.method == "POST":
         booking_form = BookingForm(request.POST)
-        slot_formset = BookingSlotFormSet(request.POST)
+        slot_formset = BookingSlotFormSet(
+            request.POST,
+            form_kwargs={"listing": listing},)
         # For each form, set the listing.
         for form in slot_formset.forms:
             form.listing = listing
@@ -124,8 +126,10 @@ def book_listing(request, listing_id):
     else:
         booking_form = BookingForm()
         slot_formset = BookingSlotFormSet()
-        for form in slot_formset.forms:
-            form.listing = listing
+        # Pass the listing via form_kwargs
+        slot_formset = BookingSlotFormSet(
+            form_kwargs={'listing': listing}
+        )
 
     return render(
         request,

--- a/booking/views.py
+++ b/booking/views.py
@@ -99,7 +99,8 @@ def book_listing(request, listing_id):
         booking_form = BookingForm(request.POST)
         slot_formset = BookingSlotFormSet(
             request.POST,
-            form_kwargs={"listing": listing},)
+            form_kwargs={"listing": listing},
+        )
         # For each form, set the listing.
         for form in slot_formset.forms:
             form.listing = listing
@@ -127,9 +128,7 @@ def book_listing(request, listing_id):
         booking_form = BookingForm()
         slot_formset = BookingSlotFormSet()
         # Pass the listing via form_kwargs
-        slot_formset = BookingSlotFormSet(
-            form_kwargs={'listing': listing}
-        )
+        slot_formset = BookingSlotFormSet(form_kwargs={"listing": listing})
 
     return render(
         request,

--- a/listings/forms.py
+++ b/listings/forms.py
@@ -26,8 +26,12 @@ class ListingSlotForm(forms.ModelForm):
         model = ListingSlot
         fields = ["start_date", "start_time", "end_date", "end_time"]
         widgets = {
-            "start_date": forms.DateInput(attrs={"type": "date"}),
-            "end_date": forms.DateInput(attrs={"type": "date"}),
+            "start_date": forms.DateInput(attrs={
+                "type": "date",
+                "min": datetime.today().date().strftime("%Y-%m-%d"),}),
+            "end_date": forms.DateInput(attrs={
+                "type": "date",
+                "min": datetime.today().date().strftime("%Y-%m-%d"),}),
         }
 
     def clean(self):

--- a/listings/forms.py
+++ b/listings/forms.py
@@ -26,12 +26,18 @@ class ListingSlotForm(forms.ModelForm):
         model = ListingSlot
         fields = ["start_date", "start_time", "end_date", "end_time"]
         widgets = {
-            "start_date": forms.DateInput(attrs={
-                "type": "date",
-                "min": datetime.today().date().strftime("%Y-%m-%d"),}),
-            "end_date": forms.DateInput(attrs={
-                "type": "date",
-                "min": datetime.today().date().strftime("%Y-%m-%d"),}),
+            "start_date": forms.DateInput(
+                attrs={
+                    "type": "date",
+                    "min": datetime.today().date().strftime("%Y-%m-%d"),
+                }
+            ),
+            "end_date": forms.DateInput(
+                attrs={
+                    "type": "date",
+                    "min": datetime.today().date().strftime("%Y-%m-%d"),
+                }
+            ),
         }
 
     def clean(self):

--- a/listings/models.py
+++ b/listings/models.py
@@ -53,34 +53,38 @@ class Listing(models.Model):
             elif iv_start > coverage_start:
                 return False
         return False
-    
-    #These two properties allow us to access the start and end date and time of a listing
+
+    # These two properties allow us to access the start and end date and time of a listing
     @property
     def earliest_start_datetime(self):
         """Returns the earliest start date and time from all slots."""
         # First find the earliest date
-        earliest_date = self.slots.aggregate(earliest_date=Min('start_date'))['earliest_date']
+        earliest_date = self.slots.aggregate(earliest_date=Min("start_date"))[
+            "earliest_date"
+        ]
         if not earliest_date:
             return None
-            
+
         # Then among slots with that date, find the earliest time
         earliest_time = self.slots.filter(start_date=earliest_date).aggregate(
-            earliest_time=Min('start_time'))['earliest_time']
-            
+            earliest_time=Min("start_time")
+        )["earliest_time"]
+
         return dt.datetime.combine(earliest_date, earliest_time)
 
     @property
     def latest_end_datetime(self):
         """Returns the latest end date and time from all slots."""
         # First find the latest date
-        latest_date = self.slots.aggregate(latest_date=Max('end_date'))['latest_date']
+        latest_date = self.slots.aggregate(latest_date=Max("end_date"))["latest_date"]
         if not latest_date:
             return None
-            
+
         # Then among slots with that date, find the latest time
         latest_time = self.slots.filter(end_date=latest_date).aggregate(
-            latest_time=Max('end_time'))['latest_time']
-            
+            latest_time=Max("end_time")
+        )["latest_time"]
+
         return dt.datetime.combine(latest_date, latest_time)
 
 

--- a/listings/models.py
+++ b/listings/models.py
@@ -1,6 +1,7 @@
 import datetime as dt
 from django.db import models
 from django.contrib.auth.models import User
+from django.db.models import Max, Min
 
 
 class Listing(models.Model):
@@ -52,6 +53,35 @@ class Listing(models.Model):
             elif iv_start > coverage_start:
                 return False
         return False
+    
+    #These two properties allow us to access the start and end date and time of a listing
+    @property
+    def earliest_start_datetime(self):
+        """Returns the earliest start date and time from all slots."""
+        # First find the earliest date
+        earliest_date = self.slots.aggregate(earliest_date=Min('start_date'))['earliest_date']
+        if not earliest_date:
+            return None
+            
+        # Then among slots with that date, find the earliest time
+        earliest_time = self.slots.filter(start_date=earliest_date).aggregate(
+            earliest_time=Min('start_time'))['earliest_time']
+            
+        return dt.datetime.combine(earliest_date, earliest_time)
+
+    @property
+    def latest_end_datetime(self):
+        """Returns the latest end date and time from all slots."""
+        # First find the latest date
+        latest_date = self.slots.aggregate(latest_date=Max('end_date'))['latest_date']
+        if not latest_date:
+            return None
+            
+        # Then among slots with that date, find the latest time
+        latest_time = self.slots.filter(end_date=latest_date).aggregate(
+            latest_time=Max('end_time'))['latest_time']
+            
+        return dt.datetime.combine(latest_date, latest_time)
 
 
 class ListingSlot(models.Model):

--- a/listings/templates/listings/view_listings.html
+++ b/listings/templates/listings/view_listings.html
@@ -324,4 +324,30 @@
   crossorigin=""
 ></script>
 <script src="{% static 'listings/js/view_listings.js' %}"></script>
+<script>
+  document.addEventListener('DOMContentLoaded', function() {
+    // Get today's date in YYYY-MM-DD format
+    const today = new Date().toISOString().split('T')[0];
+    
+    // Apply minimum date to all date inputs
+    const dateInputs = document.querySelectorAll('input[type="date"]');
+    dateInputs.forEach(input => {
+      input.min = today;
+    });
+    
+    // Handle dynamically added intervals
+    const addIntervalBtn = document.getElementById('add-interval');
+    if (addIntervalBtn) {
+      addIntervalBtn.addEventListener('click', function() {
+        // Set timeout to allow DOM to update
+        setTimeout(() => {
+          const newDateInputs = document.querySelectorAll('input[type="date"]:not([min])');
+          newDateInputs.forEach(input => {
+            input.min = today;
+          });
+        }, 100);
+      });
+    }
+  });
+</script>
 {% endblock %}

--- a/listings/tests/test_models.py
+++ b/listings/tests/test_models.py
@@ -161,19 +161,19 @@ class ListingModelTest(TestCase):
         """Test earliest_start_datetime for a listing with a single slot."""
         # Clear any existing slots
         ListingSlot.objects.filter(listing=self.listing).delete()
-        
+
         today = dt.date.today()
         slot_time = dt.time(9, 30)
-        
+
         # Create a slot
         ListingSlot.objects.create(
             listing=self.listing,
             start_date=today,
             start_time=slot_time,
             end_date=today,
-            end_time=dt.time(17, 0)
+            end_time=dt.time(17, 0),
         )
-        
+
         expected_datetime = dt.datetime.combine(today, slot_time)
         self.assertEqual(self.listing.earliest_start_datetime, expected_datetime)
 
@@ -181,19 +181,19 @@ class ListingModelTest(TestCase):
         """Test latest_end_datetime for a listing with a single slot."""
         # Clear any existing slots
         ListingSlot.objects.filter(listing=self.listing).delete()
-        
+
         today = dt.date.today()
         slot_time = dt.time(17, 30)
-        
+
         # Create a slot
         ListingSlot.objects.create(
             listing=self.listing,
             start_date=today,
             start_time=dt.time(9, 0),
             end_date=today,
-            end_time=slot_time
+            end_time=slot_time,
         )
-        
+
         expected_datetime = dt.datetime.combine(today, slot_time)
         self.assertEqual(self.listing.latest_end_datetime, expected_datetime)
 
@@ -201,27 +201,26 @@ class ListingModelTest(TestCase):
         """Test earliest_start_datetime with slots on different dates."""
         # Clear any existing slots
         ListingSlot.objects.filter(listing=self.listing).delete()
-        
+
         today = dt.date.today()
-        tomorrow = today + dt.timedelta(days=1)
         yesterday = today - dt.timedelta(days=1)
-        
+
         # Create slots on different dates
         ListingSlot.objects.create(
             listing=self.listing,
             start_date=today,
             start_time=dt.time(9, 0),
             end_date=today,
-            end_time=dt.time(17, 0)
+            end_time=dt.time(17, 0),
         )
         ListingSlot.objects.create(
             listing=self.listing,
             start_date=yesterday,
             start_time=dt.time(8, 0),
             end_date=yesterday,
-            end_time=dt.time(16, 0)
+            end_time=dt.time(16, 0),
         )
-        
+
         expected_datetime = dt.datetime.combine(yesterday, dt.time(8, 0))
         self.assertEqual(self.listing.earliest_start_datetime, expected_datetime)
 
@@ -229,26 +228,26 @@ class ListingModelTest(TestCase):
         """Test latest_end_datetime with slots on different dates."""
         # Clear any existing slots
         ListingSlot.objects.filter(listing=self.listing).delete()
-        
+
         today = dt.date.today()
         tomorrow = today + dt.timedelta(days=1)
-        
+
         # Create slots on different dates
         ListingSlot.objects.create(
             listing=self.listing,
             start_date=today,
             start_time=dt.time(9, 0),
             end_date=today,
-            end_time=dt.time(17, 0)
+            end_time=dt.time(17, 0),
         )
         ListingSlot.objects.create(
             listing=self.listing,
             start_date=tomorrow,
             start_time=dt.time(10, 0),
             end_date=tomorrow,
-            end_time=dt.time(18, 0)
+            end_time=dt.time(18, 0),
         )
-        
+
         expected_datetime = dt.datetime.combine(tomorrow, dt.time(18, 0))
         self.assertEqual(self.listing.latest_end_datetime, expected_datetime)
 

--- a/listings/tests/test_models.py
+++ b/listings/tests/test_models.py
@@ -145,6 +145,113 @@ class ListingModelTest(TestCase):
         end_dt = dt.datetime.combine(today, dt.time(17, 0))
         self.assertTrue(self.listing.is_available_for_range(start_dt, end_dt))
 
+    def test_earliest_start_datetime_no_slots(self):
+        """Test earliest_start_datetime returns None when there are no slots."""
+        # Make sure self.listing has no slots
+        ListingSlot.objects.filter(listing=self.listing).delete()
+        self.assertIsNone(self.listing.earliest_start_datetime)
+
+    def test_latest_end_datetime_no_slots(self):
+        """Test latest_end_datetime returns None when there are no slots."""
+        # Make sure self.listing has no slots
+        ListingSlot.objects.filter(listing=self.listing).delete()
+        self.assertIsNone(self.listing.latest_end_datetime)
+
+    def test_earliest_start_datetime_single_slot(self):
+        """Test earliest_start_datetime for a listing with a single slot."""
+        # Clear any existing slots
+        ListingSlot.objects.filter(listing=self.listing).delete()
+        
+        today = dt.date.today()
+        slot_time = dt.time(9, 30)
+        
+        # Create a slot
+        ListingSlot.objects.create(
+            listing=self.listing,
+            start_date=today,
+            start_time=slot_time,
+            end_date=today,
+            end_time=dt.time(17, 0)
+        )
+        
+        expected_datetime = dt.datetime.combine(today, slot_time)
+        self.assertEqual(self.listing.earliest_start_datetime, expected_datetime)
+
+    def test_latest_end_datetime_single_slot(self):
+        """Test latest_end_datetime for a listing with a single slot."""
+        # Clear any existing slots
+        ListingSlot.objects.filter(listing=self.listing).delete()
+        
+        today = dt.date.today()
+        slot_time = dt.time(17, 30)
+        
+        # Create a slot
+        ListingSlot.objects.create(
+            listing=self.listing,
+            start_date=today,
+            start_time=dt.time(9, 0),
+            end_date=today,
+            end_time=slot_time
+        )
+        
+        expected_datetime = dt.datetime.combine(today, slot_time)
+        self.assertEqual(self.listing.latest_end_datetime, expected_datetime)
+
+    def test_earliest_start_datetime_multiple_dates(self):
+        """Test earliest_start_datetime with slots on different dates."""
+        # Clear any existing slots
+        ListingSlot.objects.filter(listing=self.listing).delete()
+        
+        today = dt.date.today()
+        tomorrow = today + dt.timedelta(days=1)
+        yesterday = today - dt.timedelta(days=1)
+        
+        # Create slots on different dates
+        ListingSlot.objects.create(
+            listing=self.listing,
+            start_date=today,
+            start_time=dt.time(9, 0),
+            end_date=today,
+            end_time=dt.time(17, 0)
+        )
+        ListingSlot.objects.create(
+            listing=self.listing,
+            start_date=yesterday,
+            start_time=dt.time(8, 0),
+            end_date=yesterday,
+            end_time=dt.time(16, 0)
+        )
+        
+        expected_datetime = dt.datetime.combine(yesterday, dt.time(8, 0))
+        self.assertEqual(self.listing.earliest_start_datetime, expected_datetime)
+
+    def test_latest_end_datetime_multiple_dates(self):
+        """Test latest_end_datetime with slots on different dates."""
+        # Clear any existing slots
+        ListingSlot.objects.filter(listing=self.listing).delete()
+        
+        today = dt.date.today()
+        tomorrow = today + dt.timedelta(days=1)
+        
+        # Create slots on different dates
+        ListingSlot.objects.create(
+            listing=self.listing,
+            start_date=today,
+            start_time=dt.time(9, 0),
+            end_date=today,
+            end_time=dt.time(17, 0)
+        )
+        ListingSlot.objects.create(
+            listing=self.listing,
+            start_date=tomorrow,
+            start_time=dt.time(10, 0),
+            end_date=tomorrow,
+            end_time=dt.time(18, 0)
+        )
+        
+        expected_datetime = dt.datetime.combine(tomorrow, dt.time(18, 0))
+        self.assertEqual(self.listing.latest_end_datetime, expected_datetime)
+
 
 class ListingSlotModelTest(TestCase):
 


### PR DESCRIPTION
added calendar restrictions:

For viewing, posting and editing listings you can't select earlier than today's date 

For booking you can't select earlier than the max of today's date and the earliest available booking slot left and later than the last available time slot left 

Also added test