### PR TITLE
Recurring filter option

### DIFF
--- a/listings/templates/listings/view_listings.html
+++ b/listings/templates/listings/view_listings.html
@@ -57,6 +57,19 @@
     </div>
   </div>
 
+  <!-- Add this where you want to display messages -->
+  {% if error_messages %}
+      {% for message in error_messages %}
+          <div class="alert alert-danger">{{ message }}</div>
+      {% endfor %}
+  {% endif %}
+
+  {% if warning_messages %}
+      {% for message in warning_messages %}
+          <div class="alert alert-warning">{{ message }}</div>
+      {% endfor %}
+  {% endif %}
+
   <!-- View Toggle Buttons -->
   <div class="view-toggle text-center mb-4">
     <div class="btn-group" role="group">
@@ -93,6 +106,11 @@
                      {% if filter_type == "multiple" %}checked{% endif %}>
               <label class="form-check-label" for="filter_multiple">Multiple Intervals</label>
             </div>
+            <div class="form-check form-check-inline">
+              <input class="form-check-input" type="radio" name="filter_type" id="filter_recurring" value="recurring"
+                     {% if filter_type == "recurring" %}checked{% endif %}>
+              <label class="form-check-label" for="filter_recurring">Recurring</label>
+            </div>
           </div>
         </div>
         
@@ -110,7 +128,7 @@
       <hr class="my-2">
       
       <!-- Single Interval Filter Section -->
-      <div id="single-filter" class="mt-3" {% if filter_type == "multiple" %}style="display:none;"{% endif %}>
+      <div id="single-filter" class="mt-3" {% if filter_type != "single" %}style="display:none;"{% endif %}>
         <h6 class="filter-section-title"><i class="fas fa-calendar-alt me-2"></i>Select Date and Time</h6>
         <div class="row g-2">
           <div class="col-md-3">
@@ -185,6 +203,102 @@
                   <option value="{{ value }}" {% if request.GET.end_time_1 == value %}selected{% endif %}>{{ label }}</option>
                 {% endfor %}
               </select>
+            </div>
+          </div>
+        </div>
+      </div>
+      
+      <!-- Recurring Filter Section -->
+      <div id="recurring-filter" class="mt-3" {% if filter_type != "recurring" %}style="display:none;"{% endif %}>
+        <div class="d-flex justify-content-between align-items-center mb-2">
+          <h6 class="filter-section-title mb-0"><i class="fas fa-calendar-alt me-2"></i>Recurring Booking Pattern</h6>
+        </div>
+        
+        <!-- First line: Start date, Start time, End time, Overnight checkbox -->
+        <div class="row g-2 mb-3">
+          <!-- Start Date -->
+          <div class="col-md-3">
+            <label for="recurring_start_date" class="form-label small">Start Date*</label>
+            <input type="date" class="form-control" id="recurring_start_date" name="recurring_start_date" 
+                   value="{{ request.GET.recurring_start_date|default_if_none:'' }}" required>
+          </div>
+          
+          <!-- Start Time -->
+          <div class="col-md-3">
+            <label for="recurring_start_time" class="form-label small">Start Time*</label>
+            <select class="form-select" id="recurring_start_time" name="recurring_start_time" required>
+              <option value="">Select time</option>
+              {% for value, label in half_hour_choices %}
+                <option value="{{ value }}" {% if request.GET.recurring_start_time == value %}selected{% endif %}>{{ label }}</option>
+              {% endfor %}
+            </select>
+          </div>
+          
+          <!-- End Time -->
+          <div class="col-md-3">
+            <label for="recurring_end_time" class="form-label small">End Time*</label>
+            <select class="form-select" id="recurring_end_time" name="recurring_end_time" required>
+              <option value="">Select time</option>
+              {% for value, label in half_hour_choices %}
+                <option value="{{ value }}" {% if request.GET.recurring_end_time == value %}selected{% endif %}>{{ label }}</option>
+              {% endfor %}
+            </select>
+          </div>
+          
+          <!-- Overnight checkbox -->
+          <div class="col-md-3">
+            <label class="form-label small d-block">&nbsp;</label> <!-- Empty label for alignment -->
+            <div class="form-check mt-2">
+              <input class="form-check-input" type="checkbox" id="recurring_overnight" name="recurring_overnight" 
+                     {% if request.GET.recurring_overnight %}checked{% endif %}>
+              <label class="form-check-label" for="recurring_overnight">
+                <i class="fas fa-moon me-1"></i> Overnight booking
+              </label>
+            </div>
+          </div>
+        </div>
+        
+        <!-- Second line: Pattern selection and conditional fields -->
+        <div class="row g-2">
+          <div class="col-12">
+            <div class="d-flex align-items-center">
+              <!-- Pattern Label -->
+              <label class="form-label small me-3 mb-0" style="min-width: 120px;">Recurring Pattern*</label>
+              
+              <!-- Daily Pattern -->
+              <div class="form-check form-check-inline me-2">
+                <input class="form-check-input" type="radio" name="recurring_pattern" id="pattern_daily" value="daily" 
+                       {% if request.GET.recurring_pattern == "daily" or not request.GET.recurring_pattern %}checked{% endif %}>
+                <label class="form-check-label" for="pattern_daily">Daily</label>
+              </div>
+              
+              <!-- Daily Pattern Fields -->
+              <div id="daily-pattern-fields" class="me-4" {% if request.GET.recurring_pattern == "weekly" %}style="display:none;"{% endif %}>
+                <div class="input-group input-group-sm">
+                  <span class="input-group-text">Until</span>
+                  <input type="date" class="form-control" id="recurring_end_date" name="recurring_end_date"
+                         value="{{ request.GET.recurring_end_date|default_if_none:'' }}" 
+                         required data-required="true">
+                </div>
+              </div>
+              
+              <!-- Weekly Pattern -->
+              <div class="form-check form-check-inline me-2">
+                <input class="form-check-input" type="radio" name="recurring_pattern" id="pattern_weekly" value="weekly"
+                       {% if request.GET.recurring_pattern == "weekly" %}checked{% endif %}>
+                <label class="form-check-label" for="pattern_weekly">Weekly</label>
+              </div>
+              
+              <!-- Weekly Pattern Fields -->
+              <div id="weekly-pattern-fields" {% if request.GET.recurring_pattern != "weekly" %}style="display:none;"{% endif %}>
+                <div class="input-group input-group-sm">
+                  <span class="input-group-text">For</span>
+                  <input type="number" class="form-control" id="recurring_weeks" name="recurring_weeks" min="1" max="52"
+                         value="{{ request.GET.recurring_weeks|default:'4' }}"
+                         required data-required="true" style="width: 70px;">
+                  <span class="input-group-text">weeks</span>
+                </div>
+              </div>
             </div>
           </div>
         </div>
@@ -340,6 +454,89 @@
 <script src="{% static 'listings/js/view_listings.js' %}"></script>
 <script>
   document.addEventListener('DOMContentLoaded', function() {
+
+   // Filter type toggle handlers
+const filterSingle = document.getElementById('filter_single');
+const filterMultiple = document.getElementById('filter_multiple');
+const filterRecurring = document.getElementById('filter_recurring');
+
+const singleFilter = document.getElementById('single-filter');
+const multipleFilter = document.getElementById('multiple-filter');
+const recurringFilter = document.getElementById('recurring-filter');
+
+// INITIALIZATION: Make sure only the selected filter is visible on page load
+if (filterSingle && filterSingle.checked) {
+  singleFilter.style.display = 'block';
+  multipleFilter.style.display = 'none';
+  recurringFilter.style.display = 'none';
+} else if (filterMultiple && filterMultiple.checked) {
+  singleFilter.style.display = 'none';
+  multipleFilter.style.display = 'block';
+  recurringFilter.style.display = 'none';
+} else if (filterRecurring && filterRecurring.checked) {
+  singleFilter.style.display = 'none';
+  multipleFilter.style.display = 'none';
+  recurringFilter.style.display = 'block';
+}
+
+// Add event listeners for filter type changes
+if (filterSingle && filterMultiple && filterRecurring) {
+  filterSingle.addEventListener('change', function() {
+    if (this.checked) {
+      singleFilter.style.display = 'block';
+      multipleFilter.style.display = 'none';
+      recurringFilter.style.display = 'none';
+    }
+  });
+  
+  filterMultiple.addEventListener('change', function() {
+    if (this.checked) {
+      singleFilter.style.display = 'none';
+      multipleFilter.style.display = 'block';
+      recurringFilter.style.display = 'none';
+    }
+  });
+  
+  filterRecurring.addEventListener('change', function() {
+    if (this.checked) {
+      singleFilter.style.display = 'none';
+      multipleFilter.style.display = 'none';
+      recurringFilter.style.display = 'block';
+    }
+  });
+}
+
+// Recurring pattern toggle
+const patternDaily = document.getElementById('pattern_daily');
+const patternWeekly = document.getElementById('pattern_weekly');
+const dailyFields = document.getElementById('daily-pattern-fields');
+const weeklyFields = document.getElementById('weekly-pattern-fields');
+
+// INITIALIZATION: Make sure the correct pattern fields are visible on page load
+if (patternDaily && patternWeekly) {
+  if (patternDaily.checked) {
+    dailyFields.style.display = 'block';
+    weeklyFields.style.display = 'none';
+  } else if (patternWeekly.checked) {
+    dailyFields.style.display = 'none';
+    weeklyFields.style.display = 'block';
+  }
+  
+  patternDaily.addEventListener('change', function() {
+    if (this.checked) {
+      dailyFields.style.display = 'block';
+      weeklyFields.style.display = 'none';
+    }
+  });
+  
+  patternWeekly.addEventListener('change', function() {
+    if (this.checked) {
+      dailyFields.style.display = 'none';
+      weeklyFields.style.display = 'block';
+    }
+  });
+}
+    
     // Get today's date in YYYY-MM-DD format
     const today = new Date().toISOString().split('T')[0];
     
@@ -422,6 +619,7 @@
           });
       });
     }
-  });
+}
+);
 </script>
 {% endblock %}

--- a/listings/views.py
+++ b/listings/views.py
@@ -1,5 +1,5 @@
 # listings/views.py
-from datetime import datetime
+from datetime import datetime, timedelta, time
 
 from django.contrib import messages
 from django.contrib.auth.decorators import login_required
@@ -124,6 +124,10 @@ def view_listings(request):
         except ValueError:
             pass
 
+    # Error messages list for displaying in template
+    error_messages = []
+    warning_messages = []
+
     # Apply availability filters
     if filter_type == "single":
         # Single continuous interval filter
@@ -178,6 +182,141 @@ def view_listings(request):
                 if available_for_all:
                     filtered.append(listing)
             all_listings = filtered
+
+    elif filter_type == "recurring":
+        # Extract recurring filter parameters
+        r_start_date = request.GET.get("recurring_start_date")
+        r_start_time = request.GET.get("recurring_start_time")
+        r_end_time = request.GET.get("recurring_end_time")
+        pattern = request.GET.get("recurring_pattern", "daily")
+        overnight = request.GET.get("recurring_overnight") == "on"
+
+        # Flag to track if we should apply filter
+        continue_with_filter = True
+
+        # Check that all required fields are provided
+        if r_start_date and r_start_time and r_end_time:
+            try:
+                intervals = []
+                start_date = datetime.strptime(r_start_date, "%Y-%m-%d").date()
+
+                # Validate start time < end time unless overnight is checked
+                s_time = datetime.strptime(r_start_time, "%H:%M").time()
+                e_time = datetime.strptime(r_end_time, "%H:%M").time()
+                if s_time >= e_time and not overnight:
+                    error_messages.append(
+                        "Start time must be before end time unless overnight booking is selected"
+                    )
+                    continue_with_filter = False
+
+                if pattern == "daily":
+                    # Daily pattern requires an end date
+                    r_end_date = request.GET.get("recurring_end_date")
+                    if not r_end_date:
+                        error_messages.append(
+                            "End date is required for daily recurring pattern"
+                        )
+                        continue_with_filter = False
+                    else:
+                        end_date = datetime.strptime(r_end_date, "%Y-%m-%d").date()
+
+                        # Validate end date is after start date
+                        if end_date < start_date:
+                            error_messages.append(
+                                "End date must be on or after start date"
+                            )
+                            continue_with_filter = False
+                        else:
+                            days_count = (end_date - start_date).days + 1
+
+                            # Just a warning, but no enforced cap
+                            if days_count > 90:
+                                warning_messages.append(
+                                    "Daily recurring pattern spans over 90 days, results may be limited"
+                                )
+
+                            if continue_with_filter:
+                                for day_offset in range(days_count):
+                                    current_date = start_date + timedelta(
+                                        days=day_offset
+                                    )
+                                    s_dt = datetime.combine(current_date, s_time)
+
+                                    # If overnight, end time is on the next day
+                                    end_date = current_date + timedelta(
+                                        days=1 if overnight else 0
+                                    )
+                                    e_dt = datetime.combine(end_date, e_time)
+
+                                    intervals.append((s_dt, e_dt))
+
+                elif pattern == "weekly":
+                    # Weekly pattern requires number of weeks
+                    try:
+                        weeks_str = request.GET.get("recurring_weeks")
+                        if not weeks_str:
+                            error_messages.append(
+                                "Number of weeks is required for weekly recurring pattern"
+                            )
+                            continue_with_filter = False
+                        else:
+                            weeks = int(weeks_str)
+                            if weeks <= 0:
+                                error_messages.append(
+                                    "Number of weeks must be positive"
+                                )
+                                continue_with_filter = False
+                            elif weeks > 52:
+                                warning_messages.append(
+                                    "Weekly recurring pattern spans over 52 weeks, results may be limited"
+                                )
+
+                            if continue_with_filter:
+                                for week_offset in range(weeks):
+                                    current_date = start_date + timedelta(
+                                        weeks=week_offset
+                                    )
+                                    s_dt = datetime.combine(current_date, s_time)
+
+                                    # If overnight, end time is on the next day
+                                    end_date = current_date + timedelta(
+                                        days=1 if overnight else 0
+                                    )
+                                    e_dt = datetime.combine(end_date, e_time)
+
+                                    intervals.append((s_dt, e_dt))
+                    except ValueError:
+                        error_messages.append("Invalid number of weeks")
+                        continue_with_filter = False
+
+                # Filter listings that are available for all the recurring intervals
+                if continue_with_filter and intervals:
+                    filtered = []
+                    for listing in all_listings:
+                        available_for_all = True
+                        for s_dt, e_dt in intervals:
+                            # For overnight bookings, we need to check both days
+                            if overnight and s_time >= e_time:
+                                # Check if listing has slots for both the evening and morning parts
+                                evening_available = listing.is_available_for_range(
+                                    s_dt, datetime.combine(s_dt.date(), time(23, 59))
+                                )
+                                morning_available = listing.is_available_for_range(
+                                    datetime.combine(e_dt.date(), time(0, 0)), e_dt
+                                )
+                                if not (evening_available and morning_available):
+                                    available_for_all = False
+                                    break
+                            # Normal case - use existing method
+                            elif not listing.is_available_for_range(s_dt, e_dt):
+                                available_for_all = False
+                                break
+                        if available_for_all:
+                            filtered.append(listing)
+                    all_listings = filtered
+
+            except ValueError:
+                error_messages.append("Invalid date or time format")
 
     # Add extra display information to each listing BEFORE pagination
     if isinstance(all_listings, list):
@@ -236,8 +375,18 @@ def view_listings(request):
         "end_time": request.GET.get("end_time", ""),
         # For multiple intervals, also pass the interval_count and the individual interval fields as needed.
         "interval_count": request.GET.get("interval_count", "0"),
+        # Add recurring filter parameters
+        "recurring_pattern": request.GET.get("recurring_pattern", "daily"),
+        "recurring_start_date": request.GET.get("recurring_start_date", ""),
+        "recurring_end_date": request.GET.get("recurring_end_date", ""),
+        "recurring_start_time": request.GET.get("recurring_start_time", ""),
+        "recurring_end_time": request.GET.get("recurring_end_time", ""),
+        "recurring_weeks": request.GET.get("recurring_weeks", "4"),
+        "recurring_overnight": "on" if request.GET.get("recurring_overnight") else "",
         "has_next": page_obj.has_next(),
         "next_page": int(page_number) + 1 if page_obj.has_next() else None,
+        "error_messages": error_messages,
+        "warning_messages": warning_messages,
     }
 
     # Handle AJAX requests for "Load More"


### PR DESCRIPTION
Always filtering for user who are looking for recurring spots. 

Users can filter by a daily recurrence, in which case the filter will look for all listings that have availability between the start and end time on every day between the start and end day.

Users can also filter by a weekly recurrence, in which case the filter will look for all listings that have availability between the start and end time on the same day every week for a user input number of weeks.

I also included an overnight button that allows the user to specify that the end start will be on a second day so that it doesn't trigger a warning for the end time being before the start time.

Created tests to go along with it.

This is somewhat of a proof of concept, so if we like it then we can implement it for the booking system as well.