### PR TITLE
Fixed bug regarding reviews and added tests

### DIFF
--- a/booking/models.py
+++ b/booking/models.py
@@ -5,6 +5,8 @@ from django.core.mail import send_mail
 from django.conf import settings
 from django.template.loader import render_to_string
 from django.utils.html import strip_tags
+from django.utils import timezone
+import datetime as dt
 
 
 class Booking(models.Model):
@@ -66,6 +68,47 @@ class Booking(models.Model):
         # Send email for new bookings or status changes
         if is_new or (old_status and old_status != self.status):
             self.send_confirmation_email()
+
+    @property
+    def is_reviewed(self):
+        """Check if booking has been reviewed."""
+        return hasattr(self, 'review')
+    
+    @property
+    def is_within_24_hours(self):
+        """Check if any slot is within 24 hours from now."""
+        now = timezone.now()
+        time_threshold = now + dt.timedelta(hours=24)
+        
+        for slot in self.slots.all():
+            slot_start = timezone.make_aware(
+                dt.datetime.combine(slot.start_date, slot.start_time),
+                timezone.get_current_timezone()
+            )
+            if now <= slot_start <= time_threshold:
+                return True
+        return False
+    
+    @property
+    def has_passed(self):
+        """Check if all booking slots have passed."""
+        if not self.slots.exists():
+            return False
+            
+        now = timezone.now()
+        for slot in self.slots.all():
+            slot_end = timezone.make_aware(
+                dt.datetime.combine(slot.end_date, slot.end_time), 
+                timezone.get_current_timezone()
+            )
+            if slot_end > now:
+                return False
+        return True
+    
+    @property
+    def can_be_reviewed(self):
+        """Determine if booking can be reviewed."""
+        return self.status == "APPROVED" and self.has_passed and not self.is_reviewed
 
 
 class BookingSlot(models.Model):

--- a/booking/models.py
+++ b/booking/models.py
@@ -72,39 +72,39 @@ class Booking(models.Model):
     @property
     def is_reviewed(self):
         """Check if booking has been reviewed."""
-        return hasattr(self, 'review')
-    
+        return hasattr(self, "review")
+
     @property
     def is_within_24_hours(self):
         """Check if any slot is within 24 hours from now."""
         now = timezone.now()
         time_threshold = now + dt.timedelta(hours=24)
-        
+
         for slot in self.slots.all():
             slot_start = timezone.make_aware(
                 dt.datetime.combine(slot.start_date, slot.start_time),
-                timezone.get_current_timezone()
+                timezone.get_current_timezone(),
             )
             if now <= slot_start <= time_threshold:
                 return True
         return False
-    
+
     @property
     def has_passed(self):
         """Check if all booking slots have passed."""
         if not self.slots.exists():
             return False
-            
+
         now = timezone.now()
         for slot in self.slots.all():
             slot_end = timezone.make_aware(
-                dt.datetime.combine(slot.end_date, slot.end_time), 
-                timezone.get_current_timezone()
+                dt.datetime.combine(slot.end_date, slot.end_time),
+                timezone.get_current_timezone(),
             )
             if slot_end > now:
                 return False
         return True
-    
+
     @property
     def can_be_reviewed(self):
         """Determine if booking can be reviewed."""

--- a/booking/templates/booking/my_bookings.html
+++ b/booking/templates/booking/my_bookings.html
@@ -96,7 +96,11 @@
                 </div>
                 <div>
                   {% if not booking.is_reviewed %}
-                    {% if booking.can_be_reviewed %}
+                    {% if booking.status == "APPROVED" and booking.is_within_24_hours %}
+                      <div class="alert alert-info mb-0 py-2 px-3">
+                        <i class="fas fa-info-circle me-1"></i>Booked - To make changes please contact owner
+                      </div>
+                    {% elif booking.can_be_reviewed %}
                       <a href="{% url 'review_booking' booking.id %}" class="btn btn-primary btn-sm">
                         <i class="fas fa-star me-1"></i>Review
                       </a>

--- a/listings/views.py
+++ b/listings/views.py
@@ -454,9 +454,9 @@ def view_listings(request):
                 all_listings = Listing.objects.none()
 
     if isinstance(all_listings, list):
-        all_listings.sort(key=lambda x: x.id)
+        all_listings.sort(key=lambda x: x.id, reverse=True)
     else:
-        all_listings = all_listings.order_by("id")
+        all_listings = all_listings.order_by("-id")  # Note the minus sign
 
     processed_listings = []
     for listing in all_listings:
@@ -479,7 +479,7 @@ def view_listings(request):
         processed_listings.append(listing)
 
     page_number = request.GET.get("page", 1)
-    paginator = Paginator(processed_listings, 25)
+    paginator = Paginator(processed_listings, 10)
     page_obj = paginator.get_page(page_number)
 
     context = {


### PR DESCRIPTION
This PR fixes a bug related to booking reviews and introduces new tests to verify booking properties.

- Adds new booking properties (is_reviewed, is_within_24_hours, has_passed, can_be_reviewed) to determine review eligibility and time constraints.

- Enhances the test suite by incorporating tests that validate the functionality of these properties.

- Made it so the listings are displayed in reverse id order, so that the newest listings are displayed first. Also decreased pagination to 10 to decrease lag
