### PR TITLE
More tests for listings

### DIFF
--- a/listings/tests/test_forms.py
+++ b/listings/tests/test_forms.py
@@ -1,323 +1,208 @@
-from decimal import Decimal
+from datetime import date, datetime, time, timedelta
+from unittest.mock import patch
+
 from django.test import TestCase
-from django import forms
-from django.contrib.auth import get_user_model
-from listings.forms import ListingForm, validate_non_overlapping_slots
-import datetime
+from django.contrib.auth.models import User
+
+from listings.forms import (
+    ListingForm,
+    ListingSlotForm,
+    validate_non_overlapping_slots,
+    ReviewForm,
+)
+from listings.models import Listing
 
 
-class MockForm:
-    def __init__(self, cleaned_data):
-        self.cleaned_data = cleaned_data
-
-
-class TestValidateNonOverlappingSlots(TestCase):
-    def test_non_overlapping_slots_pass_validation(self):
-        """Test that non-overlapping slots pass validation."""
-        formset = [
-            MockForm(
-                {
-                    "start_date": datetime.date(2023, 1, 1),
-                    "start_time": "09:00",
-                    "end_date": datetime.date(2023, 1, 1),
-                    "end_time": "12:00",
-                }
-            ),
-            MockForm(
-                {
-                    "start_date": datetime.date(2023, 1, 1),
-                    "start_time": "13:00",
-                    "end_date": datetime.date(2023, 1, 1),
-                    "end_time": "15:00",
-                }
-            ),
-            MockForm(
-                {
-                    "start_date": datetime.date(2023, 1, 2),
-                    "start_time": "09:00",
-                    "end_date": datetime.date(2023, 1, 2),
-                    "end_time": "12:00",
-                }
-            ),
-        ]
-
-        # Should not raise an exception
-        validate_non_overlapping_slots(formset)
-
-    def test_adjacent_slots_pass_validation(self):
-        """Test that adjacent slots (one ends when another begins) pass validation."""
-        formset = [
-            MockForm(
-                {
-                    "start_date": datetime.date(2023, 1, 1),
-                    "start_time": "09:00",
-                    "end_date": datetime.date(2023, 1, 1),
-                    "end_time": "12:00",
-                }
-            ),
-            MockForm(
-                {
-                    "start_date": datetime.date(2023, 1, 1),
-                    "start_time": "12:00",
-                    "end_date": datetime.date(2023, 1, 1),
-                    "end_time": "15:00",
-                }
-            ),
-        ]
-
-        # Should not raise an exception
-        validate_non_overlapping_slots(formset)
-
-    def test_overlapping_slots_fail_validation(self):
-        """Test that overlapping slots fail validation."""
-        formset = [
-            MockForm(
-                {
-                    "start_date": datetime.date(2023, 1, 1),
-                    "start_time": "09:00",
-                    "end_date": datetime.date(2023, 1, 1),
-                    "end_time": "12:00",
-                }
-            ),
-            MockForm(
-                {
-                    "start_date": datetime.date(2023, 1, 1),
-                    "start_time": "11:00",
-                    "end_date": datetime.date(2023, 1, 1),
-                    "end_time": "14:00",
-                }
-            ),
-        ]
-
-        # Should raise ValidationError
-        with self.assertRaises(forms.ValidationError):
-            validate_non_overlapping_slots(formset)
-
-    def test_overlapping_across_days_fail_validation(self):
-        """Test that slots overlapping across days fail validation."""
-        formset = [
-            MockForm(
-                {
-                    "start_date": datetime.date(2023, 1, 1),
-                    "start_time": "20:00",
-                    "end_date": datetime.date(2023, 1, 2),
-                    "end_time": "10:00",
-                }
-            ),
-            MockForm(
-                {
-                    "start_date": datetime.date(2023, 1, 2),
-                    "start_time": "09:00",
-                    "end_date": datetime.date(2023, 1, 2),
-                    "end_time": "12:00",
-                }
-            ),
-        ]
-
-        # Should raise ValidationError
-        with self.assertRaises(forms.ValidationError):
-            validate_non_overlapping_slots(formset)
-
-    def test_deleted_form_ignored(self):
-        """Test that forms marked for deletion are ignored in validation."""
-        formset = [
-            MockForm(
-                {
-                    "start_date": datetime.date(2023, 1, 1),
-                    "start_time": "09:00",
-                    "end_date": datetime.date(2023, 1, 1),
-                    "end_time": "12:00",
-                }
-            ),
-            MockForm(
-                {
-                    "start_date": datetime.date(2023, 1, 1),
-                    "start_time": "11:00",
-                    "end_date": datetime.date(2023, 1, 1),
-                    "end_time": "14:00",
-                    "DELETE": True,  # This form should be ignored
-                }
-            ),
-        ]
-
-        # Should not raise an exception because the overlapping form is marked for deletion
-        validate_non_overlapping_slots(formset)
-
-    def test_incomplete_form_data_handled(self):
-        """Test that forms with missing fields don't cause errors."""
-        formset = [
-            MockForm(
-                {
-                    "start_date": datetime.date(2023, 1, 1),
-                    "start_time": "09:00",
-                    "end_date": datetime.date(2023, 1, 1),
-                    "end_time": "12:00",
-                }
-            ),
-            MockForm(
-                {
-                    "start_date": datetime.date(2023, 1, 1),
-                    # Missing start_time
-                    "end_date": datetime.date(2023, 1, 1),
-                    "end_time": "14:00",
-                }
-            ),
-        ]
-
-        # Should not raise an exception as incomplete forms are skipped
-        validate_non_overlapping_slots(formset)
-
-
-class TestEVChargerForm(TestCase):
+class ListingFormTests(TestCase):
     def setUp(self):
-        self.form_data = {
-            "title": "Test Parking Space",
-            "location": "POINT(1 1)",
-            "rent_per_hour": Decimal("25.00"),
-            "description": "A nice parking space for testing",
+        self.user = User.objects.create_user(username="formuser", password="pass")
+        self.valid_data = {
+            "title": "Test Listing",
+            "location": "123, Main Street, City, State, 12345, Country",
+            "rent_per_hour": "10.00",
+            "description": "A test listing",
+            "has_ev_charger": False,
+            "charger_level": "L2",
+            "connector_type": "J1772",
         }
 
-    def test_ev_charger_required_fields(self):
-        """Test that charger_level and connector_type are required when has_ev_charger=True"""
-        # Form with has_ev_charger=True but missing charger fields
-        data = self.form_data.copy()
-        data["has_ev_charger"] = True
+    def test_new_listing_form_valid(self):
+        form = ListingForm(data=self.valid_data)
+        self.assertTrue(form.is_valid())
+        cleaned = form.clean()
+        # When has_ev_charger is False, the EV fields should be cleared.
+        self.assertEqual(cleaned.get("charger_level"), "")
+        self.assertEqual(cleaned.get("connector_type"), "")
 
+    def test_existing_listing_location_disabled(self):
+        # Create a listing using valid_data (has_ev_charger is already in valid_data)
+        listing = Listing.objects.create(user=self.user, **self.valid_data)
+        form = ListingForm(instance=listing)
+        self.assertTrue(form.fields["location"].disabled)
+
+    def test_ev_charger_required_when_enabled(self):
+        data = self.valid_data.copy()
+        data["has_ev_charger"] = True
+        data["charger_level"] = ""
+        data["connector_type"] = ""
         form = ListingForm(data=data)
         self.assertFalse(form.is_valid())
         self.assertIn("charger_level", form.errors)
         self.assertIn("connector_type", form.errors)
 
-        # Adding the required fields should make the form valid
+    def test_save_clears_ev_fields_when_disabled(self):
+        data = self.valid_data.copy()
+        data["has_ev_charger"] = False
         data["charger_level"] = "L2"
         data["connector_type"] = "J1772"
-
         form = ListingForm(data=data)
         self.assertTrue(form.is_valid())
-
-    def test_ev_fields_cleared_when_no_charger(self):
-        """Test that charger fields are cleared when has_ev_charger=False"""
-        data = self.form_data.copy()
-        data["has_ev_charger"] = False
-        data["charger_level"] = "L3"  # Should be cleared
-        data["connector_type"] = "TESLA"  # Should be cleared
-
-        form = ListingForm(data=data)
-        self.assertTrue(form.is_valid())
-
-        # Test that the cleaned data has empty charger fields
+        # Save with commit=False so we can assign the required user.
         listing = form.save(commit=False)
+        listing.user = self.user
+        listing.save()
         self.assertEqual(listing.charger_level, "")
         self.assertEqual(listing.connector_type, "")
 
-    def test_form_field_attributes(self):
-        """Test that EV charger form fields have the correct attributes"""
-        form = ListingForm()
 
-        # Check CSS classes
-        self.assertIn(
-            "ev-charger-option",
-            form.fields["charger_level"].widget.attrs.get("class", ""),
+class ListingSlotFormTests(TestCase):
+    def setUp(self):
+        self.user = User.objects.create_user(username="slotformuser", password="pass")
+        self.listing = Listing.objects.create(
+            user=self.user,
+            title="Slot Form Listing",
+            location="456 Main St",
+            rent_per_hour="15.00",
+            description="Test slot form",
+            has_ev_charger=False,
         )
-        self.assertIn(
-            "ev-charger-option",
-            form.fields["connector_type"].widget.attrs.get("class", ""),
-        )
+        # Use a future date so that the "start time not in past" rule is not triggered by default.
+        self.future_date = date.today() + timedelta(days=1)
 
-    def test_initial_disabled_state(self):
-        """Test that charger fields are initially disabled based on has_ev_charger"""
-        # When has_ev_charger is initially False
-        form = ListingForm(initial={"has_ev_charger": False})
-
-        self.assertIn("disabled", form.fields["charger_level"].widget.attrs)
-        self.assertIn("disabled", form.fields["connector_type"].widget.attrs)
-
-        # When has_ev_charger is initially True
-        form = ListingForm(initial={"has_ev_charger": True})
-
-        self.assertNotIn("disabled", form.fields["charger_level"].widget.attrs)
-        self.assertNotIn("disabled", form.fields["connector_type"].widget.attrs)
-
-    def test_editing_listing_with_ev_charger(self):
-        """Test editing a listing that already has EV charger info"""
-        user = get_user_model().objects.create_user(
-            username="testuser", email="test@example.com", password="password123"
-        )
-
-        from listings.models import Listing
-
-        # Create a listing with EV charger
-        existing_listing = Listing.objects.create(
-            user=user,
-            title="Existing EV Spot",
-            location="POINT(1 1)",
-            rent_per_hour=Decimal("30.00"),
-            description="Already has EV charger",
-            has_ev_charger=True,
-            charger_level="L2",
-            connector_type="J1772",
-        )
-
-        # Test form loads with correct initial values
-        form = ListingForm(instance=existing_listing)
-        self.assertTrue(form.initial["has_ev_charger"])
-        self.assertEqual(form.initial["charger_level"], "L2")
-        self.assertEqual(form.initial["connector_type"], "J1772")
-
-        # Test updating EV info
+    def test_valid_slot_form(self):
         data = {
-            "title": "Updated EV Spot",
-            "location": "POINT(1 1)",
-            "rent_per_hour": Decimal("35.00"),
-            "description": "Updated description",
-            "has_ev_charger": True,
-            "charger_level": "L3",
-            "connector_type": "TESLA",
+            "start_date": self.future_date.strftime("%Y-%m-%d"),
+            "end_date": self.future_date.strftime("%Y-%m-%d"),
+            "start_time": "10:00",
+            "end_time": "10:30",
         }
+        form = ListingSlotForm(data=data)
+        self.assertTrue(form.is_valid())
 
-        update_form = ListingForm(data=data, instance=existing_listing)
-        self.assertTrue(update_form.is_valid())
-
-        updated_listing = update_form.save()
-        self.assertEqual(updated_listing.charger_level, "L3")
-        self.assertEqual(updated_listing.connector_type, "TESLA")
-
-    def test_changing_ev_charger_status(self):
-        """Test changing a listing from having EV charger to not having one"""
-        user = get_user_model().objects.create_user(
-            username="testuser2", email="test2@example.com", password="password123"
-        )
-
-        from listings.models import Listing
-
-        # Create a listing with EV charger
-        existing_listing = Listing.objects.create(
-            user=user,
-            title="EV Spot to Update",
-            location="POINT(1 1)",
-            rent_per_hour=Decimal("30.00"),
-            description="Has EV charger initially",
-            has_ev_charger=True,
-            charger_level="L2",
-            connector_type="J1772",
-        )
-
-        # Change to no EV charger
+    def test_invalid_date_order(self):
         data = {
-            "title": "No Longer EV Spot",
-            "location": "POINT(1 1)",
-            "rent_per_hour": Decimal("25.00"),
-            "description": "No longer has EV charger",
-            "has_ev_charger": False,
-            # Including values that should be cleared
-            "charger_level": "L2",
-            "connector_type": "J1772",
+            "start_date": (self.future_date + timedelta(days=1)).strftime("%Y-%m-%d"),
+            "end_date": self.future_date.strftime("%Y-%m-%d"),
+            "start_time": "08:00",
+            "end_time": "09:00",
         }
+        form = ListingSlotForm(data=data)
+        self.assertFalse(form.is_valid())
+        self.assertIn(
+            "Start date cannot be after end date.", form.errors.get("__all__", [])
+        )
 
-        update_form = ListingForm(data=data, instance=existing_listing)
-        self.assertTrue(update_form.is_valid())
+    def test_invalid_time_order_same_day(self):
+        data = {
+            "start_date": self.future_date.strftime("%Y-%m-%d"),
+            "end_date": self.future_date.strftime("%Y-%m-%d"),
+            "start_time": "09:00",
+            "end_time": "09:00",
+        }
+        form = ListingSlotForm(data=data)
+        self.assertFalse(form.is_valid())
+        self.assertIn(
+            "End time must be later than start time on the same day.",
+            form.errors.get("__all__", []),
+        )
 
-        updated_listing = update_form.save()
-        self.assertFalse(updated_listing.has_ev_charger)
-        self.assertEqual(updated_listing.charger_level, "")
-        self.assertEqual(updated_listing.connector_type, "")
+    def test_start_time_not_in_past(self):
+        # Fix "now" by patching datetime in listings.forms.
+        fixed_now = datetime.combine(date.today(), time(12, 0))
+        from listings.forms import ListingSlotForm
+
+        with patch("listings.forms.datetime") as mock_datetime:
+            mock_datetime.now.return_value = fixed_now
+            mock_datetime.today.return_value = fixed_now
+            mock_datetime.combine = datetime.combine
+            mock_datetime.strptime = datetime.strptime
+            data = {
+                "start_date": date.today().strftime("%Y-%m-%d"),
+                "end_date": date.today().strftime("%Y-%m-%d"),
+                "start_time": "09:00",
+                "end_time": "09:30",
+            }
+            form = ListingSlotForm(data=data)
+            self.assertFalse(form.is_valid())
+            # Check for the custom error message substring.
+            self.assertIn("Start time cannot be in the past", str(form.errors))
+
+
+class ReviewFormTests(TestCase):
+    def test_valid_review_form(self):
+        data = {"rating": 4, "comment": "Good listing"}
+        form = ReviewForm(data=data)
+        self.assertTrue(form.is_valid())
+
+    def test_invalid_rating(self):
+        data = {"rating": 6, "comment": "Too high rating"}
+        form = ReviewForm(data=data)
+        self.assertFalse(form.is_valid())
+        self.assertIn("Rating must be between 1 and 5", str(form.errors))
+
+
+class ValidateNonOverlappingSlotsTests(TestCase):
+    class DummyForm:
+        def __init__(self, cleaned_data):
+            self.cleaned_data = cleaned_data
+
+    def test_non_overlapping(self):
+        forms = [
+            self.DummyForm(
+                {
+                    "start_date": date(2025, 1, 1),
+                    "start_time": "08:00",
+                    "end_date": date(2025, 1, 1),
+                    "end_time": "09:00",
+                    "DELETE": False,
+                }
+            ),
+            self.DummyForm(
+                {
+                    "start_date": date(2025, 1, 1),
+                    "start_time": "09:00",
+                    "end_date": date(2025, 1, 1),
+                    "end_time": "10:00",
+                    "DELETE": False,
+                }
+            ),
+        ]
+        try:
+            validate_non_overlapping_slots(forms)
+        except Exception as e:
+            self.fail(f"Unexpected exception: {e}")
+
+    def test_overlapping(self):
+        forms = [
+            self.DummyForm(
+                {
+                    "start_date": date(2025, 1, 1),
+                    "start_time": "08:00",
+                    "end_date": date(2025, 1, 1),
+                    "end_time": "09:30",
+                    "DELETE": False,
+                }
+            ),
+            self.DummyForm(
+                {
+                    "start_date": date(2025, 1, 1),
+                    "start_time": "09:00",
+                    "end_date": date(2025, 1, 1),
+                    "end_time": "10:00",
+                    "DELETE": False,
+                }
+            ),
+        ]
+        with self.assertRaises(Exception) as context:
+            validate_non_overlapping_slots(forms)
+        self.assertIn("Availability slots cannot overlap", str(context.exception))

--- a/listings/tests/test_models.py
+++ b/listings/tests/test_models.py
@@ -1,393 +1,226 @@
-from django.test import TestCase
-from django.contrib.auth.models import User
-from listings.models import Listing, ListingSlot
 import datetime as dt
-from decimal import Decimal
+from django.test import TestCase
+from django.contrib.auth import get_user_model
+from listings.models import Listing, ListingSlot, Review
+from listings.utilities import simplify_location  # used by Listing.location_name
+
+User = get_user_model()
 
 
-class ListingModelTest(TestCase):
+class ListingModelTests(TestCase):
     def setUp(self):
-        # Create test user
-        self.user = User.objects.create_user(
-            username="testuser", email="test@example.com", password="password123"
-        )
+        self.user = User.objects.create_user(username="testuser", password="testpass")
 
-        # Create test listing
-        self.listing = Listing.objects.create(
+    def test_location_name_property(self):
+        location = "123, Main Street, City, State, 12345, Country"
+        listing = Listing.objects.create(
             user=self.user,
-            title="Test Space",
-            location="123 Test Street, Test City",
-            rent_per_hour=Decimal("25.50"),
-            description="A test space for testing purposes",
-        )
-
-    def test_listing_creation(self):
-        """Test the creation of a listing with all required fields."""
-        self.assertEqual(self.listing.title, "Test Space")
-        self.assertEqual(self.listing.location, "123 Test Street, Test City")
-        self.assertEqual(self.listing.rent_per_hour, Decimal("25.50"))
-        self.assertEqual(self.listing.description, "A test space for testing purposes")
-        self.assertEqual(self.listing.user, self.user)
-        self.assertIsNotNone(self.listing.created_at)
-        self.assertIsNotNone(self.listing.updated_at)
-
-    def test_string_representation(self):
-        """Test the string representation of a Listing."""
-        expected_string = "Test Space - 123 Test Street, Test City"
-        self.assertEqual(str(self.listing), expected_string)
-
-    def test_average_rating_no_reviews(self):
-        """Test average_rating returns None when there are no reviews."""
-        self.assertIsNone(self.listing.avg_rating)
-
-    def test_is_available_for_range_single_slot(self):
-        """Test availability check with a single slot covering the entire range."""
-        # Create a slot for today 9am-5pm
-        today = dt.date.today()
-        slot = ListingSlot.objects.create(
-            listing=self.listing,
-            start_date=today,
-            start_time=dt.time(9, 0),
-            end_date=today,
-            end_time=dt.time(17, 0),
-        )
-        print(slot)
-        # Test range within the slot (10am-3pm)
-        start_dt = dt.datetime.combine(today, dt.time(10, 0))
-        end_dt = dt.datetime.combine(today, dt.time(15, 0))
-        self.assertTrue(self.listing.is_available_for_range(start_dt, end_dt))
-
-        # Test range outside the slot (6pm-8pm)
-        start_dt = dt.datetime.combine(today, dt.time(18, 0))
-        end_dt = dt.datetime.combine(today, dt.time(20, 0))
-        self.assertFalse(self.listing.is_available_for_range(start_dt, end_dt))
-
-    def test_is_available_for_range_multiple_slots(self):
-        """Test availability with multiple slots that together cover the range."""
-        today = dt.date.today()
-        tomorrow = today + dt.timedelta(days=1)
-
-        # Create two consecutive slots
-        ListingSlot.objects.create(
-            listing=self.listing,
-            start_date=today,
-            start_time=dt.time(9, 0),
-            end_date=today,
-            end_time=dt.time(17, 0),
-        )
-
-        ListingSlot.objects.create(
-            listing=self.listing,
-            start_date=tomorrow,
-            start_time=dt.time(9, 0),
-            end_date=tomorrow,
-            end_time=dt.time(17, 0),
-        )
-
-        # Test range across both slots
-        start_dt = dt.datetime.combine(today, dt.time(14, 0))
-        end_dt = dt.datetime.combine(tomorrow, dt.time(12, 0))
-        self.assertFalse(self.listing.is_available_for_range(start_dt, end_dt))
-
-        # Create a continuous slot bridging the gap
-        ListingSlot.objects.create(
-            listing=self.listing,
-            start_date=today,
-            start_time=dt.time(17, 0),
-            end_date=tomorrow,
-            end_time=dt.time(9, 0),
-        )
-
-        # Now the range should be covered
-        self.assertTrue(self.listing.is_available_for_range(start_dt, end_dt))
-
-    def test_is_available_for_range_with_gap(self):
-        """Test availability with multiple slots that have a gap between them."""
-        today = dt.date.today()
-
-        # Create two slots with a gap between them
-        ListingSlot.objects.create(
-            listing=self.listing,
-            start_date=today,
-            start_time=dt.time(9, 0),
-            end_date=today,
-            end_time=dt.time(12, 0),
-        )
-
-        ListingSlot.objects.create(
-            listing=self.listing,
-            start_date=today,
-            start_time=dt.time(14, 0),
-            end_date=today,
-            end_time=dt.time(17, 0),
-        )
-
-        # Test range that spans the gap
-        start_dt = dt.datetime.combine(today, dt.time(11, 0))
-        end_dt = dt.datetime.combine(today, dt.time(15, 0))
-        self.assertFalse(self.listing.is_available_for_range(start_dt, end_dt))
-
-    def test_is_available_for_range_exact_match(self):
-        """Test availability when request exactly matches a slot."""
-        today = dt.date.today()
-
-        ListingSlot.objects.create(
-            listing=self.listing,
-            start_date=today,
-            start_time=dt.time(9, 0),
-            end_date=today,
-            end_time=dt.time(17, 0),
-        )
-
-        # Exact match of the slot
-        start_dt = dt.datetime.combine(today, dt.time(9, 0))
-        end_dt = dt.datetime.combine(today, dt.time(17, 0))
-        self.assertTrue(self.listing.is_available_for_range(start_dt, end_dt))
-
-    def test_earliest_start_datetime_no_slots(self):
-        """Test earliest_start_datetime returns None when there are no slots."""
-        # Make sure self.listing has no slots
-        ListingSlot.objects.filter(listing=self.listing).delete()
-        self.assertIsNone(self.listing.earliest_start_datetime)
-
-    def test_latest_end_datetime_no_slots(self):
-        """Test latest_end_datetime returns None when there are no slots."""
-        # Make sure self.listing has no slots
-        ListingSlot.objects.filter(listing=self.listing).delete()
-        self.assertIsNone(self.listing.latest_end_datetime)
-
-    def test_earliest_start_datetime_single_slot(self):
-        """Test earliest_start_datetime for a listing with a single slot."""
-        # Clear any existing slots
-        ListingSlot.objects.filter(listing=self.listing).delete()
-
-        today = dt.date.today()
-        slot_time = dt.time(9, 30)
-
-        # Create a slot
-        ListingSlot.objects.create(
-            listing=self.listing,
-            start_date=today,
-            start_time=slot_time,
-            end_date=today,
-            end_time=dt.time(17, 0),
-        )
-
-        expected_datetime = dt.datetime.combine(today, slot_time)
-        self.assertEqual(self.listing.earliest_start_datetime, expected_datetime)
-
-    def test_latest_end_datetime_single_slot(self):
-        """Test latest_end_datetime for a listing with a single slot."""
-        # Clear any existing slots
-        ListingSlot.objects.filter(listing=self.listing).delete()
-
-        today = dt.date.today()
-        slot_time = dt.time(17, 30)
-
-        # Create a slot
-        ListingSlot.objects.create(
-            listing=self.listing,
-            start_date=today,
-            start_time=dt.time(9, 0),
-            end_date=today,
-            end_time=slot_time,
-        )
-
-        expected_datetime = dt.datetime.combine(today, slot_time)
-        self.assertEqual(self.listing.latest_end_datetime, expected_datetime)
-
-    def test_earliest_start_datetime_multiple_dates(self):
-        """Test earliest_start_datetime with slots on different dates."""
-        # Clear any existing slots
-        ListingSlot.objects.filter(listing=self.listing).delete()
-
-        today = dt.date.today()
-        yesterday = today - dt.timedelta(days=1)
-
-        # Create slots on different dates
-        ListingSlot.objects.create(
-            listing=self.listing,
-            start_date=today,
-            start_time=dt.time(9, 0),
-            end_date=today,
-            end_time=dt.time(17, 0),
-        )
-        ListingSlot.objects.create(
-            listing=self.listing,
-            start_date=yesterday,
-            start_time=dt.time(8, 0),
-            end_date=yesterday,
-            end_time=dt.time(16, 0),
-        )
-
-        expected_datetime = dt.datetime.combine(yesterday, dt.time(8, 0))
-        self.assertEqual(self.listing.earliest_start_datetime, expected_datetime)
-
-    def test_latest_end_datetime_multiple_dates(self):
-        """Test latest_end_datetime with slots on different dates."""
-        # Clear any existing slots
-        ListingSlot.objects.filter(listing=self.listing).delete()
-
-        today = dt.date.today()
-        tomorrow = today + dt.timedelta(days=1)
-
-        # Create slots on different dates
-        ListingSlot.objects.create(
-            listing=self.listing,
-            start_date=today,
-            start_time=dt.time(9, 0),
-            end_date=today,
-            end_time=dt.time(17, 0),
-        )
-        ListingSlot.objects.create(
-            listing=self.listing,
-            start_date=tomorrow,
-            start_time=dt.time(10, 0),
-            end_date=tomorrow,
-            end_time=dt.time(18, 0),
-        )
-
-        expected_datetime = dt.datetime.combine(tomorrow, dt.time(18, 0))
-        self.assertEqual(self.listing.latest_end_datetime, expected_datetime)
-
-    def test_ev_charger_default_values(self):
-        """Test that EV charger fields have correct default values."""
-        # Create a new listing without specifying EV charger fields
-        new_listing = Listing.objects.create(
-            user=self.user,
-            title="EV Test Space",
-            location="456 EV Street",
-            rent_per_hour=Decimal("30.00"),
-            description="A space for testing EV defaults",
-        )
-
-        # Check default values
-        self.assertFalse(new_listing.has_ev_charger)
-        self.assertEqual(new_listing.charger_level, "L2")  # Default is L2
-        self.assertEqual(new_listing.connector_type, "J1772")  # Default is J1772
-
-    def test_ev_charger_custom_values(self):
-        """Test creating a listing with custom EV charger values."""
-        ev_listing = Listing.objects.create(
-            user=self.user,
-            title="Tesla Charging Spot",
-            location="789 Tesla Ave",
-            rent_per_hour=Decimal("35.00"),
-            description="A spot with Tesla charger",
-            has_ev_charger=True,
-            charger_level="L3",
-            connector_type="TESLA",
-        )
-
-        # Check custom values were saved
-        self.assertTrue(ev_listing.has_ev_charger)
-        self.assertEqual(ev_listing.charger_level, "L3")
-        self.assertEqual(ev_listing.connector_type, "TESLA")
-
-    def test_ev_charger_display_values(self):
-        """Test that the get_charger_level_display and get_connector_type_display methods work correctly."""
-        ev_listing = Listing.objects.create(
-            user=self.user,
-            title="CCS Charging Spot",
-            location="101 CCS Blvd",
-            rent_per_hour=Decimal("40.00"),
-            description="A spot with CCS fast charger",
-            has_ev_charger=True,
-            charger_level="L3",
-            connector_type="CCS",
-        )
-
-        # Update expected strings to match your model's actual format
-        self.assertEqual(
-            ev_listing.get_charger_level_display(), "Level 3 (DC Fast Charging)"
-        )
-        self.assertEqual(
-            ev_listing.get_connector_type_display(), "CCS (Combined Charging System)"
-        )
-
-    def test_filter_by_ev_charger(self):
-        """Test filtering listings by EV charger attributes."""
-        # Clear any existing listings to avoid test pollution
-        Listing.objects.all().delete()
-
-        # Create listings with different EV charger configurations
-        Listing.objects.create(
-            user=self.user,
-            title="No Charger Spot",
-            location="No Charger St",
-            rent_per_hour=Decimal("20.00"),
-            description="No charger here",
-            has_ev_charger=False,
-        )
-
-        Listing.objects.create(
-            user=self.user,
-            title="L1 J1772 Spot",
-            location="L1 St",
-            rent_per_hour=Decimal("25.00"),
-            description="Slow charging",
-            has_ev_charger=True,
-            charger_level="L1",
-            connector_type="J1772",
-        )
-
-        Listing.objects.create(
-            user=self.user,
-            title="L2 Tesla Spot",
-            location="L2 St",
-            rent_per_hour=Decimal("30.00"),
-            description="Medium charging",
-            has_ev_charger=True,
-            charger_level="L2",
-            connector_type="TESLA",
-        )
-
-        # Test filter by has_ev_charger
-        ev_listings = Listing.objects.filter(has_ev_charger=True)
-        self.assertEqual(ev_listings.count(), 2)
-
-        # Filter by charger_level AND has_ev_charger
-        l2_listings = Listing.objects.filter(has_ev_charger=True, charger_level="L2")
-        self.assertEqual(l2_listings.count(), 1)
-        self.assertEqual(l2_listings[0].title, "L2 Tesla Spot")
-
-        # Filter by connector_type AND has_ev_charger
-        tesla_listings = Listing.objects.filter(
-            has_ev_charger=True, connector_type="TESLA"
-        )
-        self.assertEqual(tesla_listings.count(), 1)
-        self.assertEqual(tesla_listings[0].title, "L2 Tesla Spot")
-
-
-class ListingSlotModelTest(TestCase):
-    def setUp(self):
-        self.user = User.objects.create_user(
-            username="testuser", password="password123"
-        )
-        self.listing = Listing.objects.create(
-            user=self.user,
-            title="Test Space",
-            location="123 Test Street",
-            rent_per_hour=Decimal("25.50"),
+            title="Test Listing",
+            location=location,
+            rent_per_hour="10.00",
             description="Test description",
         )
+        # location_name should be simplified using the utility.
+        self.assertEqual(listing.location_name, simplify_location(location))
 
-        today = dt.date.today()
-        self.slot = ListingSlot.objects.create(
-            listing=self.listing,
-            start_date=today,
-            start_time=dt.time(9, 0),
-            end_date=today,
-            end_time=dt.time(17, 0),
+    def test_avg_rating_and_rating_count(self):
+        listing = Listing.objects.create(
+            user=self.user,
+            title="Test Listing",
+            location="123 Main St",
+            rent_per_hour="10.00",
+            description="Test description",
+        )
+        # When there are no reviews, avg_rating is None and count is 0.
+        self.assertIsNone(listing.avg_rating)
+        self.assertEqual(listing.rating_count, 0)
+        # Create two reviews.
+        from booking.models import (
+            Booking,
+        )  # review.booking is a OneToOneField to booking.Booking
+
+        booking1 = Booking.objects.create(
+            user=self.user,
+            listing=listing,
+            email="a@example.com",
+            total_price=0,
+            status="APPROVED",
+        )
+        booking2 = Booking.objects.create(
+            user=self.user,
+            listing=listing,
+            email="b@example.com",
+            total_price=0,
+            status="APPROVED",
+        )
+        Review.objects.create(
+            booking=booking1, listing=listing, user=self.user, rating=4, comment="Good"
+        )
+        Review.objects.create(
+            booking=booking2, listing=listing, user=self.user, rating=2, comment="Bad"
+        )
+        self.assertEqual(listing.avg_rating, 3)
+        self.assertEqual(listing.rating_count, 2)
+
+    def test_str_method(self):
+        listing = Listing.objects.create(
+            user=self.user,
+            title="Test Listing",
+            location="123 Main St",
+            rent_per_hour="10.00",
+            description="Test description",
+        )
+        self.assertEqual(str(listing), "Test Listing - 123 Main St")
+
+    def test_is_available_for_range_single_slot(self):
+        listing = Listing.objects.create(
+            user=self.user,
+            title="Availability Listing",
+            location="123 Main St",
+            rent_per_hour="10.00",
+            description="Test description",
+        )
+        day = dt.date(2025, 1, 1)
+        # Create a slot from 05:00 to 09:00.
+        ListingSlot.objects.create(
+            listing=listing,
+            start_date=day,
+            start_time=dt.time(5, 0),
+            end_date=day,
+            end_time=dt.time(9, 0),
+        )
+        start_dt = dt.datetime.combine(day, dt.time(5, 0))
+        end_dt = dt.datetime.combine(day, dt.time(9, 0))
+        self.assertTrue(listing.is_available_for_range(start_dt, end_dt))
+        # A subrange is available.
+        sub_start = dt.datetime.combine(day, dt.time(6, 0))
+        sub_end = dt.datetime.combine(day, dt.time(8, 0))
+        self.assertTrue(listing.is_available_for_range(sub_start, sub_end))
+        # A range extending beyond slot end fails.
+        self.assertFalse(
+            listing.is_available_for_range(
+                start_dt, dt.datetime.combine(day, dt.time(9, 30))
+            )
         )
 
-    def test_string_representation(self):
-        """Test the string representation of a ListingSlot."""
-        today = dt.date.today()
-        expected_string = f"Test Space slot: {today} 09:00:00 - {today} 17:00:00"
-        self.assertEqual(str(self.slot), expected_string)
+    def test_is_available_for_range_multiple_slots(self):
+        listing = Listing.objects.create(
+            user=self.user,
+            title="Multi Slot Listing",
+            location="123 Main St",
+            rent_per_hour="10.00",
+            description="Test description",
+        )
+        day = dt.date(2025, 1, 1)
+        # Create two contiguous slots: 05:00-07:00 and 07:00-09:00.
+        ListingSlot.objects.create(
+            listing=listing,
+            start_date=day,
+            start_time=dt.time(5, 0),
+            end_date=day,
+            end_time=dt.time(7, 0),
+        )
+        ListingSlot.objects.create(
+            listing=listing,
+            start_date=day,
+            start_time=dt.time(7, 0),
+            end_date=day,
+            end_time=dt.time(9, 0),
+        )
+        start_dt = dt.datetime.combine(day, dt.time(5, 0))
+        end_dt = dt.datetime.combine(day, dt.time(9, 0))
+        self.assertTrue(listing.is_available_for_range(start_dt, end_dt))
+        # Requesting beyond available range returns False.
+        self.assertFalse(
+            listing.is_available_for_range(
+                start_dt, dt.datetime.combine(day, dt.time(9, 30))
+            )
+        )
 
-    def test_listing_relationship(self):
-        """Test the relationship between Listing and ListingSlot."""
-        self.assertEqual(self.slot.listing, self.listing)
-        self.assertIn(self.slot, self.listing.slots.all())
+    def test_earliest_and_latest_datetime(self):
+        listing = Listing.objects.create(
+            user=self.user,
+            title="Datetime Listing",
+            location="123 Main St",
+            rent_per_hour="10.00",
+            description="Test description",
+        )
+        day = dt.date(2025, 1, 1)
+        slot1 = ListingSlot.objects.create(
+            listing=listing,
+            start_date=day,
+            start_time=dt.time(6, 0),
+            end_date=day,
+            end_time=dt.time(8, 0),
+        )
+        print(slot1)
+        slot2 = ListingSlot.objects.create(
+            listing=listing,
+            start_date=day,
+            start_time=dt.time(9, 0),
+            end_date=day,
+            end_time=dt.time(11, 0),
+        )
+        print(slot2)
+        expected_earliest = dt.datetime.combine(day, dt.time(6, 0))
+        expected_latest = dt.datetime.combine(day, dt.time(11, 0))
+        self.assertEqual(listing.earliest_start_datetime, expected_earliest)
+        self.assertEqual(listing.latest_end_datetime, expected_latest)
+
+
+class ListingSlotModelTests(TestCase):
+    def setUp(self):
+        self.user = User.objects.create_user(username="slotuser", password="pass")
+        self.listing = Listing.objects.create(
+            user=self.user,
+            title="Slot Test Listing",
+            location="456 Main St",
+            rent_per_hour="15.00",
+            description="Slot test description",
+        )
+        self.day = dt.date(2025, 1, 2)
+
+    def test_str_method(self):
+        slot = ListingSlot.objects.create(
+            listing=self.listing,
+            start_date=self.day,
+            start_time=dt.time(8, 0),
+            end_date=self.day,
+            end_time=dt.time(10, 0),
+        )
+        expected = (
+            f"{self.listing.title} slot: {self.day} 08:00:00 - {self.day} 10:00:00"
+        )
+        self.assertEqual(str(slot), expected)
+
+
+class ReviewModelTests(TestCase):
+    def setUp(self):
+        self.user = User.objects.create_user(username="reviewuser", password="pass")
+        self.listing = Listing.objects.create(
+            user=self.user,
+            title="Review Test Listing",
+            location="789 Main St",
+            rent_per_hour="20.00",
+            description="Review test description",
+        )
+        from booking.models import Booking
+
+        self.booking = Booking.objects.create(
+            user=self.user,
+            listing=self.listing,
+            email="review@example.com",
+            total_price=0,
+            status="APPROVED",
+        )
+
+    def test_str_method(self):
+        review = Review.objects.create(
+            booking=self.booking,
+            listing=self.listing,
+            user=self.user,
+            rating=5,
+            comment="Excellent",
+        )
+        expected = f"Review for {self.listing.title} by {self.user.username}"
+        self.assertEqual(str(review), expected)

--- a/listings/tests/test_utilities.py
+++ b/listings/tests/test_utilities.py
@@ -1,0 +1,63 @@
+from django.test import TestCase
+from listings.utilities import simplify_location
+
+
+class SimplifyLocationTests(TestCase):
+    def test_empty_string(self):
+        """An empty location string should return an empty string."""
+        self.assertEqual(simplify_location(""), "")
+
+    def test_single_part(self):
+        """A location string without a comma should be returned as-is."""
+        self.assertEqual(simplify_location("Central Park"), "Central Park")
+
+    def test_exact_two_parts_with_known_city(self):
+        """
+        For a location string with exactly two parts where the second part
+        is a known city, the function returns "building, street, city".
+        In this case, both street and city are the same.
+        """
+        input_str = "Empire State Building, Manhattan"
+        # building = "Empire State Building", street = "Manhattan", and since "Manhattan" is in the list,
+        # city will be "Manhattan". Expected result is "Empire State Building, Manhattan, Manhattan".
+        expected = "Empire State Building, Manhattan, Manhattan"
+        self.assertEqual(simplify_location(input_str), expected)
+
+    def test_non_institution_no_known_city(self):
+        """
+        For a non-educational address without any part matching a known city,
+        the default city "New York" is used.
+        """
+        input_str = "123 Main St, Suite 100, Some Suburb"
+        # building = "123 Main St", street = "Suite 100", city defaults to "New York"
+        expected = "123 Main St, Suite 100, New York"
+        self.assertEqual(simplify_location(input_str), expected)
+
+    def test_with_coordinates(self):
+        """
+        Coordinates (inside square brackets) are stripped out before processing.
+        """
+        input_str = "123 Main St, Suite 100, Some Suburb [40.123, -73.456]"
+        expected = "123 Main St, Suite 100, New York"
+        self.assertEqual(simplify_location(input_str), expected)
+
+    def test_educational_institution(self):
+        """
+        For educational institutions, only the building and the city are returned.
+        """
+        input_str = "Tandon School of Engineering, Johnson Street, Downtown Brooklyn, Manhattan, New York"
+        # parts: ["Tandon School of Engineering", "Johnson Street", "Downtown Brooklyn", "Manhattan", "New York"]
+        # The generator will find "Manhattan" in parts (the first match in the known list).
+        expected = "Tandon School of Engineering, Manhattan"
+        self.assertEqual(simplify_location(input_str), expected)
+
+    def test_extra_spaces(self):
+        """
+        Extra spaces should be stripped.
+        """
+        input_str = "  456 Elm St  ,   Queens  , Extra Info "
+        # parts become: ["456 Elm St", "Queens", "Extra Info"]
+        # building = "456 Elm St", street = "Queens", and since "Queens" is a known city,
+        # expected = "456 Elm St, Queens, Queens"
+        expected = "456 Elm St, Queens, Queens"
+        self.assertEqual(simplify_location(input_str), expected)

--- a/listings/tests/test_views.py
+++ b/listings/tests/test_views.py
@@ -6,70 +6,74 @@ from django.contrib.auth.models import User
 from django.test import Client, TestCase
 from django.urls import reverse
 
-from listings.forms import ListingForm
 from listings.models import Listing, ListingSlot
 from booking.models import Booking, BookingSlot
 
 
+# Updated helper function to build formset data for any count.
+def build_slot_formset_data(prefix="form", count=1, slot_data=None):
+    data = {
+        f"{prefix}-TOTAL_FORMS": str(count),
+        f"{prefix}-INITIAL_FORMS": "0",
+        f"{prefix}-MIN_NUM_FORMS": "0",
+        f"{prefix}-MAX_NUM_FORMS": "1000",
+    }
+    for i in range(count):
+        base = f"{prefix}-{i}-"
+        if slot_data and any(key.startswith(base) for key in slot_data.keys()):
+            data[base + "start_date"] = slot_data.get(base + "start_date", "2025-05-01")
+            data[base + "start_time"] = slot_data.get(base + "start_time", "09:00")
+            data[base + "end_date"] = slot_data.get(base + "end_date", "2025-05-01")
+            data[base + "end_time"] = slot_data.get(base + "end_time", "17:00")
+        else:
+            data[base + "start_date"] = "2025-05-01"
+            data[base + "start_time"] = "09:00"
+            data[base + "end_date"] = "2025-05-01"
+            data[base + "end_time"] = "17:00"
+    return data
+
+
 #############################
-# Existing Tests for create, edit, delete, reviews, EV filters, etc.
+# Tests for create_listing view.
 #############################
 
 
-class ListingViewsTests(TestCase):
+class CreateListingViewTest(TestCase):
     def setUp(self):
-        # Create a test user and log in.
-        self.user = User.objects.create_user(username="testuser", password="testpass")
         self.client = Client()
-        self.client.login(username="testuser", password="testpass")
-
-        # Create a sample listing.
-        self.listing = Listing.objects.create(
-            user=self.user,
-            title="Test Listing",
-            location="Test Location [12.34, 56.78]",
-            rent_per_hour=Decimal("10.00"),
-            description="A test listing.",
-            has_ev_charger=False,
+        # Create a verified user.
+        self.user_verified = User.objects.create_user(
+            username="verified", password="pass"
         )
-        # Create a listing slot for the sample listing.
-        ListingSlot.objects.create(
-            listing=self.listing,
-            start_date="2025-03-12",
-            start_time="10:00",
-            end_date="2025-03-12",
-            end_time="12:00",
-        )
+        # Update the auto-created profile.
+        self.user_verified.profile.is_verified = True
+        self.user_verified.profile.save()
+        self.client.login(username="verified", password="pass")
+        self.create_url = reverse("create_listing")
 
-    def _build_slot_formset_data(self, prefix="form", count=1, slot_data=None):
-        data = {
-            f"{prefix}-TOTAL_FORMS": str(count),
-            f"{prefix}-INITIAL_FORMS": "0",
-            f"{prefix}-MIN_NUM_FORMS": "0",
-            f"{prefix}-MAX_NUM_FORMS": "1000",
-        }
-        if count >= 1:
-            default_data = {
-                f"{prefix}-0-start_date": "2025-03-12",
-                f"{prefix}-0-start_time": "10:00",
-                f"{prefix}-0-end_date": "2025-03-12",
-                f"{prefix}-0-end_time": "12:00",
-            }
-            if slot_data:
-                default_data.update(slot_data)
-            data.update(default_data)
-        return data
-
-    def test_create_listing_get(self):
-        url = reverse("create_listing")
-        response = self.client.get(url)
+    def test_create_listing_get_verified(self):
+        response = self.client.get(self.create_url)
         self.assertEqual(response.status_code, 200)
         self.assertTemplateUsed(response, "listings/create_listing.html")
-        self.assertIsInstance(response.context["form"], ListingForm)
+        # Verified users see the form.
+        self.assertIn("form", response.context)
         self.assertIn("slot_formset", response.context)
 
-    def test_create_listing_view_post(self):
-        tomorrow = (datetime.now() + timedelta(days=1)).date()
+    def test_create_listing_get_not_verified(self):
+        # Create an unverified user.
+        user_unverified = User.objects.create_user(
+            username="unverified", password="pass"
+        )
+        print(user_unverified)
+        # The post_save signal auto-creates a Profile with is_verified=False.
+        self.client.login(username="unverified", password="pass")
+        response = self.client.get(self.create_url)
+        # Expect the verification card to be shown.
+        self.assertEqual(response.status_code, 200)
+        self.assertContains(response, "Verification Required")
+        self.assertNotContains(response, "Spot Details")
+
+    def test_create_listing_post_valid(self):
         listing_data = {
             "title": "New Listing",
             "description": "New Description",
@@ -80,80 +84,191 @@ class ListingViewsTests(TestCase):
             "connector_type": "",
         }
         slot_data = {
-            "form-0-start_date": tomorrow.strftime("%Y-%m-%d"),
+            "form-0-start_date": "2025-05-01",
             "form-0-start_time": "09:00",
-            "form-0-end_date": tomorrow.strftime("%Y-%m-%d"),
+            "form-0-end_date": "2025-05-01",
             "form-0-end_time": "17:00",
         }
-        formset_data = self._build_slot_formset_data(
-            prefix="form", count=1, slot_data=slot_data
-        )
-        post_data = {**listing_data, **formset_data}
-        response = self.client.post(reverse("create_listing"), post_data)
-        if response.status_code != 302:
-            print("Listing form errors:", response.context["form"].errors)
-            print("Slot formset errors:", response.context.get("slot_formset").errors)
+        post_data = {
+            **listing_data,
+            **build_slot_formset_data(prefix="form", count=1, slot_data=slot_data),
+        }
+        response = self.client.post(self.create_url, post_data)
         self.assertEqual(response.status_code, 302)
         self.assertRedirects(response, reverse("view_listings"))
         self.assertTrue(Listing.objects.filter(title="New Listing").exists())
         new_listing = Listing.objects.get(title="New Listing")
         slot = new_listing.slots.first()
-        self.assertEqual(
-            slot.start_date.strftime("%Y-%m-%d"), tomorrow.strftime("%Y-%m-%d")
-        )
+        self.assertEqual(slot.start_date.strftime("%Y-%m-%d"), "2025-05-01")
         self.assertEqual(slot.start_time.strftime("%H:%M"), "09:00")
 
-    def test_edit_listing_view_get(self):
-        url = reverse("edit_listing", args=[self.listing.id])
-        response = self.client.get(url)
-        self.assertEqual(response.status_code, 200)
-        self.assertTemplateUsed(response, "listings/edit_listing.html")
-        self.assertIsInstance(response.context["form"], ListingForm)
-        self.assertIn("slot_formset", response.context)
-
-    def test_edit_listing_view_post(self):
-        tomorrow = (datetime.now() + timedelta(days=1)).date()
+    def test_create_listing_post_invalid_form(self):
+        # Missing title to force an error.
         listing_data = {
-            "title": "Updated Listing",
-            "description": "Updated Description",
-            "rent_per_hour": "20.00",
-            "location": "Updated Location [123, 456]",
+            "title": "",
+            "description": "New Description",
+            "rent_per_hour": "15.00",
+            "location": "New Location [123, 456]",
             "has_ev_charger": False,
             "charger_level": "",
             "connector_type": "",
         }
-        slot = self.listing.slots.first()
+        post_data = {**listing_data, **build_slot_formset_data(prefix="form", count=1)}
+        response = self.client.post(self.create_url, post_data)
+        self.assertEqual(response.status_code, 200)
+        # Expect alert message in the rendered template.
+        self.assertContains(response, "Please correct the errors below")
+
+    def test_create_listing_post_overlapping_slots(self):
+        listing_data = {
+            "title": "Overlap Listing",
+            "description": "Overlap test",
+            "rent_per_hour": "15.00",
+            "location": "Overlap Location",
+            "has_ev_charger": False,
+            "charger_level": "",
+            "connector_type": "",
+        }
+        # Two slots that overlap.
         slot_data = {
-            "form-0-id": str(slot.id),
-            "form-0-start_date": tomorrow.strftime("%Y-%m-%d"),
+            "form-0-start_date": "2025-05-01",
             "form-0-start_time": "09:00",
-            "form-0-end_date": tomorrow.strftime("%Y-%m-%d"),
+            "form-0-end_date": "2025-05-01",
+            "form-0-end_time": "11:00",
+            "form-1-start_date": "2025-05-01",
+            "form-1-start_time": "10:30",
+            "form-1-end_date": "2025-05-01",
+            "form-1-end_time": "12:00",
+        }
+        post_data = {
+            **listing_data,
+            **build_slot_formset_data(prefix="form", count=2, slot_data=slot_data),
+        }
+        response = self.client.post(self.create_url, post_data)
+        # Expect the view to catch overlapping slots.
+        self.assertEqual(response.status_code, 200)
+
+
+#############################
+# Tests for edit_listing view.
+#############################
+
+
+class EditListingViewTest(TestCase):
+    def setUp(self):
+        self.client = Client()
+        self.user = User.objects.create_user(username="editor", password="pass")
+        self.client.login(username="editor", password="pass")
+        self.listing = Listing.objects.create(
+            user=self.user,
+            title="Editable Listing",
+            location="Edit Location",
+            rent_per_hour=Decimal("10.00"),
+            description="Editable",
+            has_ev_charger=False,
+        )
+        self.original_slot = ListingSlot.objects.create(
+            listing=self.listing,
+            start_date="2025-06-01",
+            start_time="10:00",
+            end_date="2025-06-01",
+            end_time="12:00",
+        )
+        self.edit_url = reverse("edit_listing", args=[self.listing.id])
+
+    def _build_edit_slot_data(self, prefix="form", count=1, slot_data=None):
+        data = {
+            f"{prefix}-TOTAL_FORMS": str(count),
+            f"{prefix}-INITIAL_FORMS": str(count),
+            f"{prefix}-MIN_NUM_FORMS": "0",
+            f"{prefix}-MAX_NUM_FORMS": "1000",
+        }
+        if count >= 1:
+            # Ensure that start_date is a string.
+            slot_date = self.original_slot.start_date
+            if not isinstance(slot_date, str):
+                slot_date = slot_date.strftime("%Y-%m-%d")
+            default_data = {
+                f"{prefix}-0-id": str(self.original_slot.id),
+                f"{prefix}-0-start_date": slot_date,
+                f"{prefix}-0-start_time": "10:00",
+                f"{prefix}-0-end_date": slot_date,
+                f"{prefix}-0-end_time": "12:00",
+            }
+            if slot_data:
+                default_data.update(slot_data)
+            data.update(default_data)
+        return data
+
+    def test_edit_listing_get(self):
+        response = self.client.get(self.edit_url)
+        self.assertEqual(response.status_code, 200)
+        self.assertTemplateUsed(response, "listings/edit_listing.html")
+        self.assertIn("form", response.context)
+        self.assertIn("slot_formset", response.context)
+
+    def test_edit_listing_post_valid(self):
+        new_date = "2025-06-02"
+        listing_data = {
+            "title": "Updated Listing",
+            "description": "Updated Desc",
+            "rent_per_hour": "20.00",
+            "location": self.listing.location,
+            "has_ev_charger": False,
+            "charger_level": "",
+            "connector_type": "",
+        }
+        slot_data = {
+            "form-0-id": str(self.original_slot.id),
+            "form-0-start_date": new_date,
+            "form-0-start_time": "09:00",
+            "form-0-end_date": new_date,
             "form-0-end_time": "17:00",
         }
-        formset_data = {
-            "form-TOTAL_FORMS": "1",
-            "form-INITIAL_FORMS": "1",
-            "form-MIN_NUM_FORMS": "0",
-            "form-MAX_NUM_FORMS": "1000",
-        }
-        formset_data.update(slot_data)
-        post_data = {**listing_data, **formset_data}
-        response = self.client.post(
-            reverse("edit_listing", args=[self.listing.id]), post_data
+        formset_data = self._build_edit_slot_data(
+            prefix="form", count=1, slot_data=slot_data
         )
-        if response.status_code != 302:
-            print("Listing form errors:", response.context["form"].errors)
-            print("Slot formset errors:", response.context.get("slot_formset").errors)
+        post_data = {**listing_data, **formset_data}
+        response = self.client.post(self.edit_url, post_data)
+        self.assertEqual(response.status_code, 302)
         self.assertRedirects(response, reverse("manage_listings"))
         self.listing.refresh_from_db()
         self.assertEqual(self.listing.title, "Updated Listing")
         updated_slot = self.listing.slots.first()
-        self.assertEqual(
-            updated_slot.start_date.strftime("%Y-%m-%d"), tomorrow.strftime("%Y-%m-%d")
-        )
+        self.assertEqual(updated_slot.start_date.strftime("%Y-%m-%d"), new_date)
         self.assertEqual(updated_slot.start_time.strftime("%H:%M"), "09:00")
 
-    def test_edit_listing_pending_bookings(self):
+    def test_edit_listing_overlapping_slots_error(self):
+        listing_data = {
+            "title": "Overlap Edit",
+            "description": "Overlap conflict",
+            "rent_per_hour": "10.00",
+            "location": self.listing.location,
+            "has_ev_charger": False,
+            "charger_level": "",
+            "connector_type": "",
+        }
+        slot_data = {
+            "form-TOTAL_FORMS": "2",
+            "form-INITIAL_FORMS": "1",
+            "form-MIN_NUM_FORMS": "0",
+            "form-MAX_NUM_FORMS": "1000",
+            "form-0-id": str(self.original_slot.id),
+            "form-0-start_date": "2025-06-01",
+            "form-0-start_time": "10:00",
+            "form-0-end_date": "2025-06-01",
+            "form-0-end_time": "12:00",
+            "form-1-start_date": "2025-06-01",
+            "form-1-start_time": "11:00",
+            "form-1-end_date": "2025-06-01",
+            "form-1-end_time": "13:00",
+        }
+        post_data = {**listing_data, **slot_data}
+        response = self.client.post(self.edit_url, post_data)
+        self.assertEqual(response.status_code, 200)
+        self.assertContains(response, "Overlapping slots detected. Please correct.")
+
+    def test_edit_listing_pending_bookings_block(self):
         Booking.objects.create(
             user=self.user,
             listing=self.listing,
@@ -161,19 +276,18 @@ class ListingViewsTests(TestCase):
             total_price=0,
             status="PENDING",
         )
-        url = reverse("edit_listing", args=[self.listing.id])
         listing_data = {
-            "title": "Attempted Edit",
-            "description": "Attempt edit with pending booking",
+            "title": "Blocked Edit",
+            "description": "Should not allow edit",
             "rent_per_hour": "12.00",
             "location": self.listing.location,
             "has_ev_charger": False,
             "charger_level": "",
             "connector_type": "",
         }
-        slot_data = self._build_slot_formset_data(prefix="form", count=1)
+        slot_data = self._build_edit_slot_data(prefix="form", count=1)
         post_data = {**listing_data, **slot_data}
-        response = self.client.post(url, post_data)
+        response = self.client.post(self.edit_url, post_data)
         self.assertEqual(response.status_code, 200)
         self.assertContains(
             response, "You cannot edit your listing while there is a pending booking"
@@ -187,100 +301,64 @@ class ListingViewsTests(TestCase):
             total_price=0,
             status="APPROVED",
         )
+        # Convert start_date to string if necessary.
+        slot_date = self.original_slot.start_date
+        if not isinstance(slot_date, str):
+            slot_date_str = slot_date.strftime("%Y-%m-%d")
+        else:
+            slot_date_str = slot_date
         BookingSlot.objects.create(
             booking=booking,
-            start_date=self.listing.slots.first().start_date,
+            start_date=datetime.strptime(slot_date_str, "%Y-%m-%d").date(),
             start_time="10:00",
-            end_date=self.listing.slots.first().start_date,
+            end_date=datetime.strptime(slot_date_str, "%Y-%m-%d").date(),
             end_time="12:00",
         )
-        url = reverse("edit_listing", args=[self.listing.id])
         listing_data = {
             "title": "Conflict Edit",
-            "description": "Conflicting interval",
+            "description": "Conflicting availability",
             "rent_per_hour": "10.00",
             "location": self.listing.location,
             "has_ev_charger": False,
             "charger_level": "",
             "connector_type": "",
         }
-        print(url)
         slot_data = {
             "form-TOTAL_FORMS": "1",
             "form-INITIAL_FORMS": "0",
             "form-MIN_NUM_FORMS": "0",
             "form-MAX_NUM_FORMS": "1000",
-            "form-0-start_date": self.listing.slots.first().start_date.strftime(
-                "%Y-%m-%d"
-            ),
+            "form-0-start_date": slot_date_str,
             "form-0-start_time": "11:00",
-            "form-0-end_date": self.listing.slots.first().start_date.strftime(
-                "%Y-%m-%d"
-            ),
+            "form-0-end_date": slot_date_str,
             "form-0-end_time": "13:00",
         }
         post_data = {**listing_data, **slot_data}
-        response = self.client.post(
-            reverse("edit_listing", args=[self.listing.id]), post_data
-        )
+        response = self.client.post(self.edit_url, post_data)
         self.assertEqual(response.status_code, 200)
-        self.assertContains(response, "conflict with an active booking")
+        self.assertContains(response, "Your changes conflict with an active booking")
 
-    def test_delete_listing_view_get(self):
-        url = reverse("delete_listing", args=[self.listing.id])
-        response = self.client.get(url)
-        self.assertEqual(response.status_code, 200)
-        self.assertTemplateUsed(response, "listings/confirm_delete.html")
-
-    def test_delete_listing_view_post(self):
-        url = reverse("delete_listing", args=[self.listing.id])
-        response = self.client.post(url)
-        self.assertEqual(response.status_code, 302)
-        self.assertRedirects(response, reverse("manage_listings"))
-        self.assertFalse(Listing.objects.filter(id=self.listing.id).exists())
-
-    def test_delete_listing_active_booking(self):
-        Booking.objects.create(
-            user=self.user,
+    def test_edit_listing_get_updates_ongoing_slot_initial(self):
+        current_dt = datetime.now()
+        ongoing_slot = ListingSlot.objects.create(
             listing=self.listing,
-            email="conflict@example.com",
-            total_price=0,
-            status="PENDING",
+            start_date=current_dt.date(),
+            start_time=(current_dt - timedelta(hours=1)).strftime("%H:%M"),
+            end_date=current_dt.date(),
+            end_time=(current_dt + timedelta(hours=1)).strftime("%H:%M"),
         )
-        url = reverse("delete_listing", args=[self.listing.id])
-        response = self.client.get(url)
+        response = self.client.get(self.edit_url)
         self.assertEqual(response.status_code, 200)
-        self.assertContains(response, "Cannot delete listing with pending bookings")
-
-    def test_listing_reviews_view(self):
-        url = reverse("listing_reviews", args=[self.listing.id])
-        booking = Booking.objects.create(
-            user=self.user,
-            listing=self.listing,
-            email="review@example.com",
-            total_price=0,
-            status="APPROVED",
-        )
-        from listings.models import Review
-
-        Review.objects.create(
-            booking=booking,
-            listing=self.listing,
-            user=self.user,
-            rating=5,
-            comment="Great!",
-        )
-        response = self.client.get(url)
-        self.assertEqual(response.status_code, 200)
-        self.assertTemplateUsed(response, "listings/listing_reviews.html")
-        self.assertIn("reviews", response.context)
+        formset = response.context["slot_formset"]
+        found = False
+        for form in formset.forms:
+            if form.instance.id == ongoing_slot.id:
+                self.assertIn("start_time", form.initial)
+                found = True
+        self.assertTrue(found)
 
 
-#############################
-# New Tests for recurring filters (covering lines 356–427)
-#############################
-
-
+# --- Tests for view_listings ---
 class ListingsFilterTest(TestCase):
     def setUp(self):
         self.client = Client()
@@ -288,7 +366,7 @@ class ListingsFilterTest(TestCase):
         self.client.login(username="filteruser", password="pass")
         # Set test_date to a future date.
         self.test_date = date.today() + timedelta(days=10)
-        # Create listings for filtering.
+        # Listing 1: Future Listing.
         self.future_listing = Listing.objects.create(
             user=self.user,
             title="Future Listing",
@@ -303,6 +381,7 @@ class ListingsFilterTest(TestCase):
             end_date=self.test_date + timedelta(days=5),
             end_time=time(17, 0),
         )
+        # Listing 2: Today Future Time.
         self.today_future = Listing.objects.create(
             user=self.user,
             title="Today Future Time",
@@ -317,6 +396,7 @@ class ListingsFilterTest(TestCase):
             end_date=self.test_date,
             end_time=time(18, 0),
         )
+        # Listing 3: Today Past Time.
         self.today_past = Listing.objects.create(
             user=self.user,
             title="Today Past Time",
@@ -379,8 +459,7 @@ class ListingsFilterTest(TestCase):
             "end_time": "15:00",
         }
         response = self.client.get(url, params)
-        context_listings = response.context["listings"]
-        titles = [listing.title for listing in context_listings]
+        titles = [listing.title for listing in response.context["listings"]]
         self.assertIn("Future Listing", titles)
         self.assertIn("Today Future Time", titles)
         self.assertNotIn("Today Past Time", titles)
@@ -423,7 +502,6 @@ class ListingsFilterTest(TestCase):
         response = self.client.get(url, params)
         titles = [listing.title for listing in response.context["listings"]]
         self.assertIn("Multi Interval Listing", titles)
-        # Change second interval so it is not covered.
         params["start_time_2"] = "15:30"
         params["end_time_2"] = "16:30"
         response = self.client.get(url, params)
@@ -438,15 +516,13 @@ class ListingsFilterTest(TestCase):
             "recurring_start_date": self.test_date.strftime("%Y-%m-%d"),
             "recurring_end_date": self.test_date.strftime("%Y-%m-%d"),
             "recurring_start_time": "14:00",
-            "recurring_end_time": "12:00",  # invalid: end before start without overnight
+            "recurring_end_time": "12:00",  # invalid without overnight
         }
         response = self.client.get(url, params)
         self.assertIn(
             "Start time must be before end time unless overnight booking is selected",
             response.context["error_messages"],
         )
-
-    # New tests to cover lines 356-427 (recurring branch)
 
     def test_recurring_daily_missing_end_date(self):
         url = reverse("view_listings")
@@ -459,12 +535,10 @@ class ListingsFilterTest(TestCase):
             "recurring_end_time": "12:00",
         }
         response = self.client.get(url, params)
-        # Expect error about missing end date.
         self.assertIn(
             "End date is required for daily recurring pattern",
             response.context["error_messages"],
         )
-        # Since continue_with_filter is False, all_listings becomes empty.
         self.assertEqual(len(response.context["listings"]), 0)
 
     def test_recurring_daily_end_date_before_start(self):
@@ -473,7 +547,7 @@ class ListingsFilterTest(TestCase):
             "filter_type": "recurring",
             "recurring_pattern": "daily",
             "recurring_start_date": "2025-04-10",
-            "recurring_end_date": "2025-04-09",  # end date before start date
+            "recurring_end_date": "2025-04-09",
             "recurring_start_time": "10:00",
             "recurring_end_time": "12:00",
         }
@@ -518,7 +592,6 @@ class ListingsFilterTest(TestCase):
         self.assertEqual(len(response.context["listings"]), 0)
 
     def test_recurring_daily_valid(self):
-        # Create a listing with a slot covering a wide period.
         valid_listing = Listing.objects.create(
             user=self.user,
             title="Recurring Daily Listing",
@@ -527,7 +600,6 @@ class ListingsFilterTest(TestCase):
             description="Available daily",
             has_ev_charger=False,
         )
-        # Create a slot that covers a long period (e.g., from April 10 to April 20).
         start_date_slot = datetime.strptime("2025-04-10", "%Y-%m-%d").date()
         end_date_slot = datetime.strptime("2025-04-20", "%Y-%m-%d").date()
         ListingSlot.objects.create(
@@ -547,46 +619,46 @@ class ListingsFilterTest(TestCase):
             "recurring_end_time": "10:00",
         }
         response = self.client.get(url, params)
-        # Our listing should be included because its availability covers the requested intervals.
         listings = response.context["listings"]
         titles = [listing.title for listing in listings]
         self.assertIn("Recurring Daily Listing", titles)
 
-
-def test_recurring_weekly_valid(self):
-    # Create a listing with weekly availability on a specific day.
-    weekly_listing = Listing.objects.create(
-        user=self.user,
-        title="Recurring Weekly Listing",
-        location="Weekly Location",
-        rent_per_hour=25.00,
-        description="Available weekly",
-        has_ev_charger=False,
-    )
-    # Create slots for 3 consecutive Mondays starting from 2025-04-14.
-    start_date = datetime.strptime("2025-04-14", "%Y-%m-%d").date()  # Monday
-    for week_offset in range(3):
-        slot_date = start_date + timedelta(weeks=week_offset)
-        ListingSlot.objects.create(
-            listing=weekly_listing,
-            start_date=slot_date,
-            start_time="09:00",
-            end_date=slot_date,
-            end_time="17:00",
+    def test_recurring_weekly_valid(self):
+        # Create a listing with slots on 3 consecutive weeks.
+        weekly_listing = Listing.objects.create(
+            user=self.user,
+            title="Recurring Weekly Listing",
+            location="Weekly Location",
+            rent_per_hour=25.00,
+            description="Available weekly",
+            has_ev_charger=False,
         )
-    url = reverse("view_listings")
-    params = {
-        "filter_type": "recurring",
-        "recurring_pattern": "weekly",
-        "recurring_start_date": "2025-04-14",
-        "recurring_weeks": "3",
-        "recurring_start_time": "10:00",
-        "recurring_end_time": "16:00",
-    }
-    response = self.client.get(url, params)
-    listings = response.context["listings"]
-    titles = [listing.title for listing in listings]
-    self.assertIn("Recurring Weekly Listing", titles)
+        start_date = datetime.strptime("2025-04-14", "%Y-%m-%d").date()  # Monday
+        for week_offset in range(3):
+            slot_date = start_date + timedelta(weeks=week_offset)
+            ListingSlot.objects.create(
+                listing=weekly_listing,
+                start_date=slot_date,
+                start_time="09:00",
+                end_date=slot_date,
+                end_time="17:00",
+            )
+        url = reverse("view_listings")
+        params = {
+            "filter_type": "recurring",
+            "recurring_pattern": "weekly",
+            "recurring_start_date": "2025-04-14",
+            "recurring_weeks": "3",
+            "recurring_start_time": "10:00",
+            "recurring_end_time": "16:00",
+        }
+        response = self.client.get(url, params)
+        listings = response.context["listings"]
+        titles = [listing.title for listing in listings]
+        self.assertIn("Recurring Weekly Listing", titles)
+
+
+# --- Tests for manage_listings, delete_listing, and listing_reviews ---
 
 
 class ManageListingsTest(TestCase):
@@ -785,3 +857,129 @@ class EVChargerViewTest(TestCase):
         self.assertContains(response, "Tesla")
         self.assertContains(response, "fa-charging-station")
         self.assertContains(response, "fa-plug")
+
+
+# --- Tests for delete_listing and listing_reviews ---
+
+
+class DeleteListingViewTest(TestCase):
+    def setUp(self):
+        self.client = Client()
+        self.user = User.objects.create_user(username="deleter", password="pass")
+        self.client.login(username="deleter", password="pass")
+        self.listing = Listing.objects.create(
+            user=self.user,
+            title="Delete Test Listing",
+            location="Delete Loc",
+            rent_per_hour=Decimal("10.00"),
+            description="To be deleted",
+            has_ev_charger=False,
+        )
+        self.delete_url = reverse("delete_listing", args=[self.listing.id])
+
+    def test_delete_listing_view_get(self):
+        response = self.client.get(self.delete_url)
+        self.assertEqual(response.status_code, 200)
+        self.assertTemplateUsed(response, "listings/confirm_delete.html")
+
+    def test_delete_listing_view_post(self):
+        response = self.client.post(self.delete_url)
+        self.assertEqual(response.status_code, 302)
+        self.assertRedirects(response, reverse("manage_listings"))
+        self.assertFalse(Listing.objects.filter(id=self.listing.id).exists())
+
+    def test_delete_listing_active_booking(self):
+        Booking.objects.create(
+            user=self.user,
+            listing=self.listing,
+            email="conflict@example.com",
+            total_price=0,
+            status="PENDING",
+        )
+        response = self.client.get(self.delete_url)
+        self.assertEqual(response.status_code, 200)
+        self.assertContains(response, "Cannot delete listing with pending bookings")
+
+
+class ListingReviewsViewTest(TestCase):
+    def setUp(self):
+        self.client = Client()
+        self.user = User.objects.create_user(username="reviewer", password="pass")
+        self.client.login(username="reviewer", password="pass")
+        self.listing = Listing.objects.create(
+            user=self.user,
+            title="Review Test Listing",
+            location="Review Loc",
+            rent_per_hour=Decimal("10.00"),
+            description="Review test",
+            has_ev_charger=False,
+        )
+        from booking.models import Booking
+
+        self.booking = Booking.objects.create(
+            user=self.user,
+            listing=self.listing,
+            email="review@example.com",
+            total_price=0,
+            status="APPROVED",
+        )
+        from listings.models import Review
+
+        Review.objects.create(
+            booking=self.booking,
+            listing=self.listing,
+            user=self.user,
+            rating=5,
+            comment="Great!",
+        )
+
+    def test_listing_reviews_view(self):
+        url = reverse("listing_reviews", args=[self.listing.id])
+        response = self.client.get(url)
+        self.assertEqual(response.status_code, 200)
+        self.assertTemplateUsed(response, "listings/listing_reviews.html")
+        self.assertIn("reviews", response.context)
+
+
+# --- Tests covering remaining branches in view_listings (including AJAX, recurring, context) ---
+class ViewListingsContextTest(TestCase):
+    def setUp(self):
+        self.client = Client()
+        self.user = User.objects.create_user(username="contextuser", password="pass")
+        self.client.login(username="contextuser", password="pass")
+        self.listing = Listing.objects.create(
+            user=self.user,
+            title="Context Listing",
+            location="Context Loc",
+            rent_per_hour=Decimal("10.00"),
+            description="Test context",
+            has_ev_charger=False,
+        )
+        ListingSlot.objects.create(
+            listing=self.listing,
+            start_date=(date.today() + timedelta(days=1)).strftime("%Y-%m-%d"),
+            start_time="10:00",
+            end_date=(date.today() + timedelta(days=1)).strftime("%Y-%m-%d"),
+            end_time="12:00",
+        )
+        self.view_url = reverse("view_listings")
+
+    def test_view_listings_context(self):
+        response = self.client.get(self.view_url)
+        self.assertEqual(response.status_code, 200)
+        context = response.context
+        self.assertIn("half_hour_choices", context)
+        self.assertIn("error_messages", context)
+        self.assertIn("warning_messages", context)
+        self.assertIn("has_next", context)
+        self.assertIn("next_page", context)
+
+    def test_view_listings_ajax(self):
+        response = self.client.get(self.view_url, {"ajax": "1"})
+        self.assertEqual(response.status_code, 200)
+        self.assertTemplateUsed(response, "listings/partials/listing_cards.html")
+
+
+#############################
+# End of tests.
+#############################

--- a/listings/tests/test_views.py
+++ b/listings/tests/test_views.py
@@ -1,28 +1,35 @@
 from datetime import date, datetime, time, timedelta
 from decimal import Decimal
+from unittest.mock import patch
 
 from django.contrib.auth.models import User
 from django.test import Client, TestCase
 from django.urls import reverse
 
-from ..forms import ListingForm
-from ..models import Listing, ListingSlot
-from ..utilities import simplify_location
+from listings.forms import ListingForm
+from listings.models import Listing, ListingSlot
+from booking.models import Booking, BookingSlot
+
+#############################
+# Tests for views (listings/tests/test_views.py)
+#############################
 
 
 class ListingViewsTests(TestCase):
     def setUp(self):
         # Create a test user and log in.
         self.user = User.objects.create_user(username="testuser", password="testpass")
+        self.client = Client()
         self.client.login(username="testuser", password="testpass")
 
-        # Create a sample listing for tests that require an existing listing.
+        # Create a sample listing.
         self.listing = Listing.objects.create(
             user=self.user,
             title="Test Listing",
             location="Test Location [12.34, 56.78]",
             rent_per_hour=Decimal("10.00"),
             description="A test listing.",
+            has_ev_charger=False,
         )
         # Create a listing slot for the sample listing.
         ListingSlot.objects.create(
@@ -34,17 +41,12 @@ class ListingViewsTests(TestCase):
         )
 
     def _build_slot_formset_data(self, prefix="form", count=1, slot_data=None):
-        """
-        Helper method to build valid formset data for ListingSlotFormSet.
-        Optionally override default slot data.
-        """
         data = {
             f"{prefix}-TOTAL_FORMS": str(count),
             f"{prefix}-INITIAL_FORMS": "0",
             f"{prefix}-MIN_NUM_FORMS": "0",
             f"{prefix}-MAX_NUM_FORMS": "1000",
         }
-        # For one slot form, use default values (can be overridden)
         if count >= 1:
             default_data = {
                 f"{prefix}-0-start_date": "2025-03-12",
@@ -72,8 +74,10 @@ class ListingViewsTests(TestCase):
             "description": "New Description",
             "rent_per_hour": "15.00",
             "location": "New Location [123, 456]",
+            "has_ev_charger": False,
+            "charger_level": "",
+            "connector_type": "",
         }
-        # Build slot formset data using tomorrow's date and desired times.
         slot_data = {
             "form-0-start_date": tomorrow.strftime("%Y-%m-%d"),
             "form-0-start_time": "09:00",
@@ -83,9 +87,7 @@ class ListingViewsTests(TestCase):
         formset_data = self._build_slot_formset_data(
             prefix="form", count=1, slot_data=slot_data
         )
-        # Note: Do not include non-existent fields such as available_from/available_until.
         post_data = {**listing_data, **formset_data}
-
         response = self.client.post(reverse("create_listing"), post_data)
         if response.status_code != 302:
             print("Listing form errors:", response.context["form"].errors)
@@ -93,7 +95,6 @@ class ListingViewsTests(TestCase):
         self.assertEqual(response.status_code, 302)
         self.assertRedirects(response, reverse("view_listings"))
         self.assertTrue(Listing.objects.filter(title="New Listing").exists())
-        # Verify that the new listing has a slot with the correct start date and time.
         new_listing = Listing.objects.get(title="New Listing")
         slot = new_listing.slots.first()
         self.assertEqual(
@@ -116,8 +117,10 @@ class ListingViewsTests(TestCase):
             "description": "Updated Description",
             "rent_per_hour": "20.00",
             "location": "Updated Location [123, 456]",
+            "has_ev_charger": False,
+            "charger_level": "",
+            "connector_type": "",
         }
-        # For editing, include the ID of the existing slot.
         slot = self.listing.slots.first()
         slot_data = {
             "form-0-id": str(slot.id),
@@ -149,6 +152,79 @@ class ListingViewsTests(TestCase):
         )
         self.assertEqual(updated_slot.start_time.strftime("%H:%M"), "09:00")
 
+    def test_edit_listing_pending_bookings(self):
+        Booking.objects.create(
+            user=self.user,
+            listing=self.listing,
+            email="pending@example.com",
+            total_price=0,
+            status="PENDING",
+        )
+        url = reverse("edit_listing", args=[self.listing.id])
+        listing_data = {
+            "title": "Attempted Edit",
+            "description": "Attempt edit with pending booking",
+            "rent_per_hour": "12.00",
+            "location": self.listing.location,
+            "has_ev_charger": False,
+            "charger_level": "",
+            "connector_type": "",
+        }
+        slot_data = self._build_slot_formset_data(prefix="form", count=1)
+        post_data = {**listing_data, **slot_data}
+        response = self.client.post(url, post_data)
+        self.assertEqual(response.status_code, 200)
+        self.assertContains(
+            response, "You cannot edit your listing while there is a pending booking"
+        )
+
+    def test_edit_listing_active_booking_conflict(self):
+        booking = Booking.objects.create(
+            user=self.user,
+            listing=self.listing,
+            email="active@example.com",
+            total_price=0,
+            status="APPROVED",
+        )
+        BookingSlot.objects.create(
+            booking=booking,
+            start_date=self.listing.slots.first().start_date,
+            start_time="10:00",
+            end_date=self.listing.slots.first().start_date,
+            end_time="12:00",
+        )
+        url = reverse("edit_listing", args=[self.listing.id])
+        print(url)
+        listing_data = {
+            "title": "Conflict Edit",
+            "description": "Conflicting interval",
+            "rent_per_hour": "10.00",
+            "location": self.listing.location,
+            "has_ev_charger": False,
+            "charger_level": "",
+            "connector_type": "",
+        }
+        slot_data = {
+            "form-TOTAL_FORMS": "1",
+            "form-INITIAL_FORMS": "0",
+            "form-MIN_NUM_FORMS": "0",
+            "form-MAX_NUM_FORMS": "1000",
+            "form-0-start_date": self.listing.slots.first().start_date.strftime(
+                "%Y-%m-%d"
+            ),
+            "form-0-start_time": "11:00",
+            "form-0-end_date": self.listing.slots.first().start_date.strftime(
+                "%Y-%m-%d"
+            ),
+            "form-0-end_time": "13:00",
+        }
+        post_data = {**listing_data, **slot_data}
+        response = self.client.post(
+            reverse("edit_listing", args=[self.listing.id]), post_data
+        )
+        self.assertEqual(response.status_code, 200)
+        self.assertContains(response, "conflict with an active booking")
+
     def test_delete_listing_view_get(self):
         url = reverse("delete_listing", args=[self.listing.id])
         response = self.client.get(url)
@@ -162,8 +238,37 @@ class ListingViewsTests(TestCase):
         self.assertRedirects(response, reverse("manage_listings"))
         self.assertFalse(Listing.objects.filter(id=self.listing.id).exists())
 
+    def test_delete_listing_active_booking(self):
+        Booking.objects.create(
+            user=self.user,
+            listing=self.listing,
+            email="conflict@example.com",
+            total_price=0,
+            status="PENDING",
+        )
+        url = reverse("delete_listing", args=[self.listing.id])
+        response = self.client.get(url)
+        self.assertEqual(response.status_code, 200)
+        self.assertContains(response, "Cannot delete listing with pending bookings")
+
     def test_listing_reviews_view(self):
         url = reverse("listing_reviews", args=[self.listing.id])
+        booking = Booking.objects.create(
+            user=self.user,
+            listing=self.listing,
+            email="review@example.com",
+            total_price=0,
+            status="APPROVED",
+        )
+        from listings.models import Review
+
+        Review.objects.create(
+            booking=booking,
+            listing=self.listing,
+            user=self.user,
+            rating=5,
+            comment="Great!",
+        )
         response = self.client.get(url)
         self.assertEqual(response.status_code, 200)
         self.assertTemplateUsed(response, "listings/listing_reviews.html")
@@ -173,80 +278,95 @@ class ListingViewsTests(TestCase):
 class ListingsFilterTest(TestCase):
     def setUp(self):
         self.client = Client()
-        self.user = User.objects.create_user(username="testuser", password="testpass")
-        # Set a fixed test date for filtering
-        self.test_date = date(2025, 3, 15)
-
-        # Mock the current datetime to be 13:00 on test_date
-        # This ensures our "future time" tests work consistently
-        self.current_datetime = datetime.combine(self.test_date, time(13, 0))
-
-        # Patch datetime.now() to return our fixed time
-        from unittest.mock import patch
-
-        self.datetime_patcher = patch("listings.views.datetime")
-        self.mock_datetime = self.datetime_patcher.start()
-        self.mock_datetime.now.return_value = self.current_datetime
-        # Make sure strptime and combine still work
-        self.mock_datetime.strptime = datetime.strptime
-        self.mock_datetime.combine = datetime.combine
-
-    def tearDown(self):
-        # Stop patching datetime
-        self.datetime_patcher.stop()
-
-    def test_listing_time_filtering_single_interval(self):
-        # Create listings with associated slots.
-
-        # 1. Future Listing – slot from test_date 09:00 to (test_date+5 days) 17:00
-        future_listing = Listing.objects.create(
+        self.user = User.objects.create_user(username="filteruser", password="pass")
+        self.client.login(username="filteruser", password="pass")
+        # Set test_date to a future date.
+        self.test_date = date.today() + timedelta(days=5)
+        # Create Listing 1: Future Listing – available from test_date 09:00 to (test_date+5 days) 17:00.
+        self.future_listing = Listing.objects.create(
             user=self.user,
             title="Future Listing",
             location="Future Location",
-            rent_per_hour=10.0,
-            description="This should be included",
+            rent_per_hour=10.00,
+            description="Should be included",
         )
         ListingSlot.objects.create(
-            listing=future_listing,
+            listing=self.future_listing,
             start_date=self.test_date,
             start_time=time(9, 0),
             end_date=self.test_date + timedelta(days=5),
             end_time=time(17, 0),
         )
-
-        # 2. Today with future time – slot from test_date 14:00 to 18:00
-        today_future = Listing.objects.create(
+        # Listing 2: Today with future time – available on test_date 14:00 to 18:00.
+        self.today_future = Listing.objects.create(
             user=self.user,
             title="Today Future Time",
             location="Today Location",
-            rent_per_hour=10.0,
-            description="This should be included",
+            rent_per_hour=10.00,
+            description="Should be included",
         )
         ListingSlot.objects.create(
-            listing=today_future,
+            listing=self.today_future,
             start_date=self.test_date,
             start_time=time(14, 0),
             end_date=self.test_date,
             end_time=time(18, 0),
         )
-
-        # 3. Today with past time – slot from test_date 09:00 to 12:00
-        today_past = Listing.objects.create(
+        # Listing 3: Today with past time – available on test_date 09:00 to 12:00.
+        self.today_past = Listing.objects.create(
             user=self.user,
             title="Today Past Time",
-            location="Today Past Location",
-            rent_per_hour=10.0,
-            description="This should be excluded",
+            location="Past Location",
+            rent_per_hour=10.00,
+            description="Should be excluded",
         )
         ListingSlot.objects.create(
-            listing=today_past,
+            listing=self.today_past,
             start_date=self.test_date,
             start_time=time(9, 0),
             end_date=self.test_date,
             end_time=time(12, 0),
         )
 
-        # Apply single continuous interval filter
+        # Patch datetime in listings.views so that "now" is before self.test_date.
+        self.patcher = patch("listings.views.datetime")
+        self.mock_datetime = self.patcher.start()
+        fixed_now = datetime.combine(self.test_date - timedelta(days=1), time(12, 0))
+        self.mock_datetime.now.return_value = fixed_now
+        self.mock_datetime.combine = datetime.combine
+        self.mock_datetime.strptime = datetime.strptime
+
+    def tearDown(self):
+        self.patcher.stop()
+
+    def test_view_listings_default(self):
+        url = reverse("view_listings")
+        response = self.client.get(url)
+        self.assertEqual(response.status_code, 200)
+        self.assertIn("listings", response.context)
+
+    def test_view_listings_filter_max_price(self):
+        Listing.objects.create(
+            user=self.user,
+            title="Expensive Listing",
+            location="999 Rich St",
+            rent_per_hour=50.00,
+            description="Expensive",
+        )
+        url = reverse("view_listings")
+        response = self.client.get(url, {"max_price": "20"})
+        self.assertEqual(response.status_code, 200)
+        listings = response.context["listings"]
+        for listing in listings:
+            self.assertLessEqual(float(listing.rent_per_hour), 20.0)
+
+    def test_view_listings_ajax(self):
+        url = reverse("view_listings")
+        response = self.client.get(url, {"ajax": "1"})
+        self.assertEqual(response.status_code, 200)
+        self.assertTemplateUsed(response, "listings/partials/listing_cards.html")
+
+    def test_single_interval_filter(self):
         url = reverse("view_listings")
         params = {
             "filter_type": "single",
@@ -257,21 +377,18 @@ class ListingsFilterTest(TestCase):
         }
         response = self.client.get(url, params)
         context_listings = response.context["listings"]
-        listing_titles = [listing.title for listing in context_listings]
+        titles = [listing.title for listing in context_listings]
+        self.assertIn("Future Listing", titles)
+        self.assertIn("Today Future Time", titles)
+        self.assertNotIn("Today Past Time", titles)
 
-        self.assertIn("Future Listing", listing_titles)
-        self.assertIn("Today Future Time", listing_titles)
-        self.assertNotIn("Today Past Time", listing_titles)
-        self.assertEqual(len(listing_titles), 2)
-
-    def test_listing_time_filtering_multiple_intervals(self):
-        # Create a listing with two slots that together cover 10:00 to 16:00 on test_date.
+    def test_multiple_intervals_filter(self):
         multi_listing = Listing.objects.create(
             user=self.user,
             title="Multi Interval Listing",
             location="Multi Location",
-            rent_per_hour=15.0,
-            description="This listing has multiple intervals",
+            rent_per_hour=15.00,
+            description="Multiple intervals",
         )
         ListingSlot.objects.create(
             listing=multi_listing,
@@ -287,7 +404,6 @@ class ListingsFilterTest(TestCase):
             end_date=self.test_date,
             end_time=time(16, 0),
         )
-
         url = reverse("view_listings")
         params = {
             "filter_type": "multiple",
@@ -302,50 +418,100 @@ class ListingsFilterTest(TestCase):
             "end_time_2": "15:00",
         }
         response = self.client.get(url, params)
-        context_listings = response.context["listings"]
-        listing_titles = [listing.title for listing in context_listings]
-        # Listing should cover both intervals.
-        self.assertIn("Multi Interval Listing", listing_titles)
-
-        # Now change the second interval so it is not covered.
+        titles = [listing.title for listing in response.context["listings"]]
+        self.assertIn("Multi Interval Listing", titles)
         params["start_time_2"] = "15:30"
         params["end_time_2"] = "16:30"
         response = self.client.get(url, params)
-        context_listings = response.context["listings"]
-        listing_titles = [listing.title for listing in context_listings]
-        self.assertNotIn("Multi Interval Listing", listing_titles)
+        titles = [listing.title for listing in response.context["listings"]]
+        self.assertNotIn("Multi Interval Listing", titles)
+
+    def test_recurring_filter_invalid_time(self):
+        url = reverse("view_listings")
+        params = {
+            "filter_type": "recurring",
+            "recurring_pattern": "daily",
+            "recurring_start_date": self.test_date.strftime("%Y-%m-%d"),
+            "recurring_end_date": self.test_date.strftime("%Y-%m-%d"),
+            "recurring_start_time": "14:00",
+            "recurring_end_time": "12:00",
+        }
+        response = self.client.get(url, params)
+        self.assertIn(
+            "Start time must be before end time unless overnight booking is selected",
+            response.context["error_messages"],
+        )
+
+
+class ManageListingsTest(TestCase):
+    def setUp(self):
+        self.client = Client()
+        self.owner = User.objects.create_user(username="manageowner", password="pass")
+        self.client.login(username="manageowner", password="pass")
+        self.listing1 = Listing.objects.create(
+            user=self.owner,
+            title="Manage Listing 1",
+            location="Loc 1",
+            rent_per_hour=10.00,
+            description="Desc 1",
+        )
+        self.listing2 = Listing.objects.create(
+            user=self.owner,
+            title="Manage Listing 2",
+            location="Loc 2",
+            rent_per_hour=12.00,
+            description="Desc 2",
+        )
+        Booking.objects.create(
+            user=self.owner,
+            listing=self.listing1,
+            email="a@example.com",
+            total_price=0,
+            status="PENDING",
+        )
+        Booking.objects.create(
+            user=self.owner,
+            listing=self.listing2,
+            email="b@example.com",
+            total_price=0,
+            status="APPROVED",
+        )
+
+    def test_manage_listings_view(self):
+        url = reverse("manage_listings")
+        response = self.client.get(url)
+        self.assertEqual(response.status_code, 200)
+        self.assertIn("listings", response.context)
+        for listing in response.context["listings"]:
+            self.assertTrue(hasattr(listing, "pending_bookings"))
+            self.assertTrue(hasattr(listing, "approved_bookings"))
 
 
 class ListingOwnerBookingTest(TestCase):
     def setUp(self):
-        # Create two users: owner and non-owner.
-        self.owner = User.objects.create_user(username="owner", password="ownerpass123")
-        self.non_owner = User.objects.create_user(
-            username="renter", password="renterpass123"
-        )
-
-        # Create a listing owned by the owner.
+        self.client = Client()
+        self.owner = User.objects.create_user(username="owner", password="pass")
+        self.renter = User.objects.create_user(username="renter", password="pass")
         self.listing = Listing.objects.create(
             user=self.owner,
-            title="Test Parking Spot",
-            location="Test Location [123.456, 789.012]",
-            rent_per_hour=10.0,
-            description="Test Description",
+            title="Owner Parking",
+            location="Owner Loc [12,34]",
+            rent_per_hour=10.00,
+            description="Owner description",
+            has_ev_charger=False,
         )
-        # Create a slot for the listing.
         ListingSlot.objects.create(
             listing=self.listing,
-            start_date=(datetime.now() - timedelta(days=1)).date(),
-            start_time=time(9, 0),
-            end_date=(datetime.now() + timedelta(days=30)).date(),
-            end_time=time(17, 0),
+            start_date=(datetime.now() + timedelta(days=1)).date(),
+            start_time="09:00",
+            end_date=(datetime.now() + timedelta(days=1)).date(),
+            end_time="17:00",
         )
-        self.view_listings_url = reverse("view_listings")
 
     def test_owner_sees_badge_not_book_button(self):
-        """Owners should see a badge (not a 'Book Now' button)."""
-        self.client.login(username="owner", password="ownerpass123")
-        response = self.client.get(self.view_listings_url)
+        self.client.login(username="owner", password="pass")
+        url = reverse("view_listings")
+        response = self.client.get(url)
         self.assertEqual(response.status_code, 200)
         self.assertContains(response, "Your listing")
         self.assertContains(response, 'class="badge bg-secondary"')
@@ -354,9 +520,9 @@ class ListingOwnerBookingTest(TestCase):
         self.assertNotContains(response, "Book Now")
 
     def test_non_owner_sees_book_button(self):
-        """Non-owners should see the 'Book Now' button."""
-        self.client.login(username="renter", password="renterpass123")
-        response = self.client.get(self.view_listings_url)
+        self.client.login(username="renter", password="pass")
+        url = reverse("view_listings")
+        response = self.client.get(url)
         self.assertEqual(response.status_code, 200)
         self.assertNotContains(response, "Your listing")
         book_url = reverse("book_listing", args=[self.listing.id])
@@ -365,315 +531,41 @@ class ListingOwnerBookingTest(TestCase):
         self.assertContains(response, "Book Now")
 
 
-class SimplifyLocationTest(TestCase):
-    def test_simplify_location_with_institution(self):
-        # For educational institutions, the full building name is retained.
-        loc = (
-            "Tandon School of Engineering, Johnson Street, Downtown Brooklyn, Brooklyn"
-        )
-        simplified = simplify_location(loc)
-        self.assertEqual(simplified, "Tandon School of Engineering, Brooklyn")
-
-    def test_simplify_location_non_institution(self):
-        # For non-institution addresses, the first two parts plus the city are used.
-        loc = "Some Building, Some Street, Manhattan, Extra Info"
-        simplified = simplify_location(loc)
-        self.assertEqual(simplified, "Some Building, Some Street, Manhattan")
-
-    def test_simplify_location_empty(self):
-        simplified = simplify_location("")
-        self.assertEqual(simplified, "")
-
-
-class RecurringFilterTest(TestCase):
-    def setUp(self):
-        self.client = Client()
-        self.user = User.objects.create_user(username="testuser", password="testpass")
-        # Set a fixed test date for filtering
-        self.test_date = date(2025, 3, 15)  # A Saturday
-
-    # def test_daily_recurring_filter(self):
-    #     # Create a listing available every day for a week
-    #     daily_listing = Listing.objects.create(
-    #         user=self.user,
-    #         title="Daily Available Listing",
-    #         location="Daily Location",
-    #         rent_per_hour=15.0,
-    #         description="Available every day from 10:00-14:00",
-    #     )
-
-    #     # Create slots for 5 consecutive days
-    #     for i in range(5):
-    #         current_date = self.test_date + timedelta(days=i)
-    #         ListingSlot.objects.create(
-    #             listing=daily_listing,
-    #             start_date=current_date,
-    #             start_time=time(10, 0),
-    #             end_date=current_date,
-    #             end_time=time(14, 0),
-    #         )
-
-    #     # Create another listing with gaps in availability
-    #     partial_listing = Listing.objects.create(
-    #         user=self.user,
-    #         title="Partial Available Listing",
-    #         location="Partial Location",
-    #         rent_per_hour=20.0,
-    #         description="Not available every day",
-    #     )
-
-    #     # Create slots for days 0, 2, 4 (skipping days 1 and 3)
-    #     for i in range(0, 5, 2):
-    #         current_date = self.test_date + timedelta(days=i)
-    #         ListingSlot.objects.create(
-    #             listing=partial_listing,
-    #             start_date=current_date,
-    #             start_time=time(10, 0),
-    #             end_date=current_date,
-    #             end_time=time(14, 0),
-    #         )
-
-    #     # Apply daily recurring filter for 3 consecutive days
-    #     url = reverse("view_listings")
-    #     params = {
-    #         "filter_type": "recurring",
-    #         "recurring_pattern": "daily",
-    #         "recurring_start_date": self.test_date.strftime("%Y-%m-%d"),
-    #         "recurring_end_date": (self.test_date + timedelta(days=2)).strftime(
-    #             "%Y-%m-%d"
-    #         ),
-    #         "recurring_start_time": "11:00",
-    #         "recurring_end_time": "13:00",
-    #     }
-
-    #     response = self.client.get(url, params)
-    #     context_listings = response.context["listings"]
-    #     listing_titles = [listing.title for listing in context_listings]
-
-    #     # Daily listing should be included, partial listing should be excluded
-    #     self.assertIn("Daily Available Listing", listing_titles)
-    #     self.assertNotIn("Partial Available Listing", listing_titles)
-
-    def test_weekly_recurring_filter(self):
-        # Create a listing available same day every week
-        weekly_listing = Listing.objects.create(
-            user=self.user,
-            title="Weekly Available Listing",
-            location="Weekly Location",
-            rent_per_hour=25.0,
-            description="Available every Saturday",
-        )
-
-        # Create slots for 4 consecutive Saturdays
-        for i in range(0, 28, 7):  # 0, 7, 14, 21 - four Saturdays
-            current_date = self.test_date + timedelta(days=i)
-            ListingSlot.objects.create(
-                listing=weekly_listing,
-                start_date=current_date,
-                start_time=time(9, 0),
-                end_date=current_date,
-                end_time=time(17, 0),
-            )
-
-        # Create another listing with inconsistent weekly availability
-        inconsistent_listing = Listing.objects.create(
-            user=self.user,
-            title="Inconsistent Weekly Listing",
-            location="Inconsistent Location",
-            rent_per_hour=30.0,
-            description="Missing some Saturdays",
-        )
-
-        # Create slots for 1st and 3rd Saturdays only (missing 2nd and 4th)
-        for i in range(0, 28, 14):  # 0, 14 - two Saturdays
-            current_date = self.test_date + timedelta(days=i)
-            ListingSlot.objects.create(
-                listing=inconsistent_listing,
-                start_date=current_date,
-                start_time=time(9, 0),
-                end_date=current_date,
-                end_time=time(17, 0),
-            )
-
-            # NEW: Create a listing available every week but at wrong time
-        wrong_time_listing = Listing.objects.create(
-            user=self.user,
-            title="Wrong Time Weekly Listing",
-            location="Wrong Time Location",
-            rent_per_hour=35.0,
-            description="Available every Saturday but outside requested hours",
-        )
-
-        # Create slots for 4 consecutive Saturdays but only from 6-8am and 18-20pm
-        for i in range(0, 28, 7):
-            current_date = self.test_date + timedelta(days=i)
-            # Morning slot (too early)
-            ListingSlot.objects.create(
-                listing=wrong_time_listing,
-                start_date=current_date,
-                start_time=time(6, 0),
-                end_date=current_date,
-                end_time=time(8, 0),
-            )
-            # Evening slot (too late)
-            ListingSlot.objects.create(
-                listing=wrong_time_listing,
-                start_date=current_date,
-                start_time=time(18, 0),
-                end_date=current_date,
-                end_time=time(20, 0),
-            )
-
-        # Apply weekly recurring filter for 3 weeks
-        url = reverse("view_listings")
-        params = {
-            "filter_type": "recurring",
-            "recurring_pattern": "weekly",
-            "recurring_start_date": self.test_date.strftime("%Y-%m-%d"),
-            "recurring_weeks": "3",
-            "recurring_start_time": "10:00",
-            "recurring_end_time": "16:00",
-        }
-
-        response = self.client.get(url, params)
-        context_listings = response.context["listings"]
-        listing_titles = [listing.title for listing in context_listings]
-
-        # Weekly listing should be included
-        self.assertIn("Weekly Available Listing", listing_titles)
-
-        # Both inconsistent pattern and wrong time listings should be excluded
-        self.assertNotIn("Inconsistent Weekly Listing", listing_titles)
-        self.assertNotIn("Wrong Time Weekly Listing", listing_titles)
-
-    # def test_overnight_recurring_filter(self):
-    #     # Create a listing available for overnight stays (24/7)
-    #     overnight_listing = Listing.objects.create(
-    #         user=self.user,
-    #         title="Overnight Listing",
-    #         location="Overnight Location",
-    #         rent_per_hour=40.0,
-    #         description="Available for overnight stays",
-    #     )
-
-    #     # Create slots for 3 consecutive days (to cover 2 nights)
-    #     for i in range(3):
-    #         current_date = self.test_date + timedelta(days=i)
-    #         ListingSlot.objects.create(
-    #             listing=overnight_listing,
-    #             start_date=current_date,
-    #             start_time=time(0, 0),  # Available all day
-    #             end_date=current_date,
-    #             end_time=time(23, 59),
-    #         )
-
-    #     # Create a listing that's only available during daytime hours
-    #     daytime_listing = Listing.objects.create(
-    #         user=self.user,
-    #         title="Daytime Only Listing",
-    #         location="Daytime Location",
-    #         rent_per_hour=30.0,
-    #         description="Only available during daytime hours",
-    #     )
-
-    #     # Create daytime-only slots for the same 3 consecutive days
-    #     for i in range(3):
-    #         current_date = self.test_date + timedelta(days=i)
-    #         ListingSlot.objects.create(
-    #             listing=daytime_listing,
-    #             start_date=current_date,
-    #             start_time=time(9, 0),  # Available from 9am
-    #             end_date=current_date,
-    #             end_time=time(17, 0),  # Until 5pm
-    #         )
-
-    #     # Apply overnight recurring filter
-    #     url = reverse("view_listings")
-    #     params = {
-    #         "filter_type": "recurring",
-    #         "recurring_pattern": "daily",
-    #         "recurring_start_date": self.test_date.strftime("%Y-%m-%d"),
-    #         "recurring_end_date": (self.test_date + timedelta(days=1)).strftime(
-    #             "%Y-%m-%d"
-    #         ),
-    #         "recurring_start_time": "22:00",
-    #         "recurring_end_time": "08:00",  # End time is before start time, requiring overnight
-    #         "recurring_overnight": "on",
-    #     }
-
-    #     response = self.client.get(url, params)
-    #     context_listings = response.context["listings"]
-    #     listing_titles = [listing.title for listing in context_listings]
-
-    #     # Overnight listing should be included
-    #     self.assertIn("Overnight Listing", listing_titles)
-    #     # Daytime-only listing should NOT be included
-    #     self.assertNotIn("Daytime Only Listing", listing_titles)
-
-    def test_start_time_after_end_time_validation(self):
-        # Apply filter with start time after end time without overnight option
-        url = reverse("view_listings")
-        params = {
-            "filter_type": "recurring",
-            "recurring_pattern": "daily",
-            "recurring_start_date": self.test_date.strftime("%Y-%m-%d"),
-            "recurring_end_date": self.test_date.strftime("%Y-%m-%d"),
-            "recurring_start_time": "14:00",
-            "recurring_end_time": "12:00",  # End time before start time
-        }
-
-        response = self.client.get(url, params)
-
-        # Should get an error message
-        self.assertIn(
-            "Start time must be before end time unless overnight booking is selected",
-            response.context["error_messages"],
-        )
-
-
 class EVChargerViewTest(TestCase):
     def setUp(self):
         self.client = Client()
-        self.user = User.objects.create_user(username="evuser", password="evpassword")
-        self.client.login(username="evuser", password="evpassword")
-
-        # Create a non-EV listing
-        self.non_ev_listing = Listing.objects.create(
+        self.user = User.objects.create_user(username="evuser", password="evpass")
+        self.client.login(username="evuser", password="evpass")
+        self.non_ev = Listing.objects.create(
             user=self.user,
             title="Regular Parking",
-            location="Regular Location",
+            location="Regular Loc",
             rent_per_hour=Decimal("10.00"),
-            description="No EV charger here",
+            description="No EV charger",
             has_ev_charger=False,
         )
-
-        # Create an L2 J1772 listing
-        self.l2_listing = Listing.objects.create(
+        self.l2 = Listing.objects.create(
             user=self.user,
             title="Level 2 Charging",
-            location="L2 Location",
+            location="L2 Loc",
             rent_per_hour=Decimal("15.00"),
-            description="Standard Level 2 charger",
+            description="Standard charger",
             has_ev_charger=True,
             charger_level="L2",
             connector_type="J1772",
         )
-
-        # Create an L3 Tesla listing
-        self.l3_listing = Listing.objects.create(
+        self.l3 = Listing.objects.create(
             user=self.user,
             title="Fast Charging Tesla",
-            location="Tesla Location",
+            location="Tesla Loc",
             rent_per_hour=Decimal("25.00"),
-            description="DC Fast Charging for Tesla",
+            description="DC Fast Charging",
             has_ev_charger=True,
             charger_level="L3",
             connector_type="TESLA",
         )
-
-        # Create slots for all listings to ensure they appear in searches
         tomorrow = (datetime.now() + timedelta(days=1)).date()
-        for listing in [self.non_ev_listing, self.l2_listing, self.l3_listing]:
+        for listing in [self.non_ev, self.l2, self.l3]:
             ListingSlot.objects.create(
                 listing=listing,
                 start_date=tomorrow,
@@ -682,228 +574,68 @@ class EVChargerViewTest(TestCase):
                 end_time="17:00",
             )
 
-    def test_create_listing_with_ev_charger(self):
-        """Test creating a new listing with EV charger information"""
-        tomorrow = (datetime.now() + timedelta(days=1)).date()
-        listing_data = {
-            "title": "New EV Listing",
-            "description": "New EV Description",
-            "rent_per_hour": "20.00",
-            "location": "New EV Location [123, 456]",
-            "has_ev_charger": "on",  # Checkbox value when checked
-            "charger_level": "L1",
-            "connector_type": "CHAdeMO",
-        }
-
-        # Add slot formset data
-        slot_data = {
-            "form-0-start_date": tomorrow.strftime("%Y-%m-%d"),
-            "form-0-start_time": "09:00",
-            "form-0-end_date": tomorrow.strftime("%Y-%m-%d"),
-            "form-0-end_time": "17:00",
-            "form-TOTAL_FORMS": "1",
-            "form-INITIAL_FORMS": "0",
-            "form-MIN_NUM_FORMS": "0",
-            "form-MAX_NUM_FORMS": "1000",
-        }
-
-        post_data = {**listing_data, **slot_data}
-        response = self.client.post(reverse("create_listing"), post_data)
-
-        # Check redirect indicates success
-        self.assertEqual(response.status_code, 302)
-
-        # Verify listing was created with correct EV data
-        new_listing = Listing.objects.get(title="New EV Listing")
-        self.assertTrue(new_listing.has_ev_charger)
-        self.assertEqual(new_listing.charger_level, "L1")
-        self.assertEqual(new_listing.connector_type, "CHAdeMO")
-
-    def test_edit_listing_add_ev_charger(self):
-        """Test editing a non-EV listing to add EV charger information"""
-        tomorrow = (datetime.now() + timedelta(days=1)).date()
-        listing_data = {
-            "title": "Updated with EV",
-            "description": "Now with EV charger",
-            "rent_per_hour": "15.00",
-            "location": self.non_ev_listing.location,
-            "has_ev_charger": "on",
-            "charger_level": "L2",
-            "connector_type": "CCS",
-        }
-
-        # Add slot formset data for the existing slot
-        slot = self.non_ev_listing.slots.first()
-        slot_data = {
-            "form-0-id": str(slot.id),
-            "form-0-start_date": tomorrow.strftime("%Y-%m-%d"),
-            "form-0-start_time": "09:00",
-            "form-0-end_date": tomorrow.strftime("%Y-%m-%d"),
-            "form-0-end_time": "17:00",
-            "form-TOTAL_FORMS": "1",
-            "form-INITIAL_FORMS": "1",
-            "form-MIN_NUM_FORMS": "0",
-            "form-MAX_NUM_FORMS": "1000",
-        }
-
-        post_data = {**listing_data, **slot_data}
-        response = self.client.post(
-            reverse("edit_listing", args=[self.non_ev_listing.id]), post_data
-        )
-
-        # Check redirect indicates success
-        self.assertEqual(response.status_code, 302)
-
-        # Verify listing was updated with EV data
-        self.non_ev_listing.refresh_from_db()
-        self.assertTrue(self.non_ev_listing.has_ev_charger)
-        self.assertEqual(self.non_ev_listing.charger_level, "L2")
-        self.assertEqual(self.non_ev_listing.connector_type, "CCS")
-
-    def test_edit_listing_remove_ev_charger(self):
-        """Test editing an EV listing to remove EV charger information"""
-        tomorrow = (datetime.now() + timedelta(days=1)).date()
-        listing_data = {
-            "title": "No Longer EV",
-            "description": "Removed EV charger",
-            "rent_per_hour": "10.00",
-            "location": self.l2_listing.location,
-        }
-
-        # Add slot formset data for the existing slot
-        slot = self.l2_listing.slots.first()
-        slot_data = {
-            "form-0-id": str(slot.id),
-            "form-0-start_date": tomorrow.strftime("%Y-%m-%d"),
-            "form-0-start_time": "09:00",
-            "form-0-end_date": tomorrow.strftime("%Y-%m-%d"),
-            "form-0-end_time": "17:00",
-            "form-TOTAL_FORMS": "1",
-            "form-INITIAL_FORMS": "1",
-            "form-MIN_NUM_FORMS": "0",
-            "form-MAX_NUM_FORMS": "1000",
-        }
-
-        post_data = {**listing_data, **slot_data}
-        response = self.client.post(
-            reverse("edit_listing", args=[self.l2_listing.id]), post_data
-        )
-
-        # Check redirect indicates success
-        self.assertEqual(response.status_code, 302)
-
-        # Verify listing was updated with EV charger removed
-        self.l2_listing.refresh_from_db()
-        self.assertFalse(self.l2_listing.has_ev_charger)
-        self.assertEqual(self.l2_listing.charger_level, "")  # Should be cleared
-        self.assertEqual(self.l2_listing.connector_type, "")  # Should be cleared
-
     def test_filter_by_ev_charger_presence(self):
-        """Test filtering listings by presence of EV charger"""
         response = self.client.get(reverse("view_listings"), {"has_ev_charger": "on"})
-
-        # Check that filtering works
         listings = response.context["listings"]
-        listing_ids = [listing.id for listing in listings]
-
-        # Should include both EV listings
-        self.assertIn(self.l2_listing.id, listing_ids)
-        self.assertIn(self.l3_listing.id, listing_ids)
-
-        # Should exclude non-EV listing
-        self.assertNotIn(self.non_ev_listing.id, listing_ids)
+        ids = [listing.id for listing in listings]
+        self.assertIn(self.l2.id, ids)
+        self.assertIn(self.l3.id, ids)
+        self.assertNotIn(self.non_ev.id, ids)
 
     def test_filter_by_charger_level(self):
-        """Test filtering listings by specific charger level"""
         response = self.client.get(
             reverse("view_listings"), {"has_ev_charger": "on", "charger_level": "L3"}
         )
-
         listings = response.context["listings"]
-        listing_ids = [listing.id for listing in listings]
-
-        # Should include only L3 listing
-        self.assertIn(self.l3_listing.id, listing_ids)
-
-        # Should exclude L2 listing
-        self.assertNotIn(self.l2_listing.id, listing_ids)
-
-        # Should exclude non-EV listing
-        self.assertNotIn(self.non_ev_listing.id, listing_ids)
+        ids = [listing.id for listing in listings]
+        self.assertIn(self.l3.id, ids)
+        self.assertNotIn(self.l2.id, ids)
+        self.assertNotIn(self.non_ev.id, ids)
 
     def test_filter_by_connector_type(self):
-        """Test filtering listings by specific connector type"""
         response = self.client.get(
             reverse("view_listings"),
             {"has_ev_charger": "on", "connector_type": "TESLA"},
         )
-
         listings = response.context["listings"]
-        listing_ids = [listing.id for listing in listings]
-
-        # Should include only Tesla listing
-        self.assertIn(self.l3_listing.id, listing_ids)
-
-        # Should exclude J1772 listing
-        self.assertNotIn(self.l2_listing.id, listing_ids)
-
-        # Should exclude non-EV listing
-        self.assertNotIn(self.non_ev_listing.id, listing_ids)
+        ids = [listing.id for listing in listings]
+        self.assertIn(self.l3.id, ids)
+        self.assertNotIn(self.l2.id, ids)
+        self.assertNotIn(self.non_ev.id, ids)
 
     def test_combined_ev_filters(self):
-        """Test combining multiple EV filter criteria"""
-        # Create an L3 J1772 listing to test combined filters
-        l3_j1772_listing = Listing.objects.create(
+        l3_j1772 = Listing.objects.create(
             user=self.user,
             title="L3 with J1772",
-            location="L3 J1772 Location",
+            location="L3 J1772 Loc",
             rent_per_hour=Decimal("20.00"),
             description="Fast charging with J1772",
             has_ev_charger=True,
             charger_level="L3",
             connector_type="J1772",
         )
-
-        # Add slots to make it appear in searches
         tomorrow = (datetime.now() + timedelta(days=1)).date()
         ListingSlot.objects.create(
-            listing=l3_j1772_listing,
+            listing=l3_j1772,
             start_date=tomorrow,
             start_time="09:00",
             end_date=tomorrow,
             end_time="17:00",
         )
-
-        # Filter for L3 + TESLA
         response = self.client.get(
             reverse("view_listings"),
-            {"has_ev_charger": "on", "charger_level": "L3", "connector_type": "TESLA"},
+            {
+                "has_ev_charger": "on",
+                "charger_level": "L3",
+                "connector_type": "TESLA",
+            },
         )
-
         listings = response.context["listings"]
-        listing_ids = [listing.id for listing in listings]
-
-        # Should include only L3 Tesla listing
-        self.assertIn(self.l3_listing.id, listing_ids)
-
-        # Should exclude L2 J1772 listing
-        self.assertNotIn(self.l2_listing.id, listing_ids)
-
-        # Should exclude L3 J1772 listing
-        self.assertNotIn(l3_j1772_listing.id, listing_ids)
-
-    def test_ev_badge_displayed(self):
-        """Test that listings with EV chargers show the EV badge in the view"""
-        response = self.client.get(reverse("view_listings"))
-
-        # Check that EV charger details appear for L2 listing
-        self.assertContains(response, "Level 2")
-        self.assertContains(response, "J1772")
-
-        # Check that EV charger details appear for L3 listing
+        ids = [listing.id for listing in listings]
+        self.assertIn(self.l3.id, ids)
+        self.assertNotIn(self.l2.id, ids)
+        self.assertNotIn(l3_j1772.id, ids)
         self.assertContains(response, "Level 3")
         self.assertContains(response, "Tesla")
-
-        # Check badge formatting
         self.assertContains(response, "fa-charging-station")
         self.assertContains(response, "fa-plug")


### PR DESCRIPTION
This pull request introduces a new test suite for the `simplify_location` function in the `listings` app. The tests cover various scenarios to ensure the function behaves correctly when processing location strings.

New test cases added:

* [`test_empty_string`](diffhunk://#diff-4f7e8095d720b1f360a036bf0c2692ce0193faeafacc4762d5c81f8da5dee3a6R1-R63): Verifies that an empty location string returns an empty string.
* [`test_single_part`](diffhunk://#diff-4f7e8095d720b1f360a036bf0c2692ce0193faeafacc4762d5c81f8da5dee3a6R1-R63): Checks that a location string without a comma is returned as-is.
* [`test_exact_two_parts_with_known_city`](diffhunk://#diff-4f7e8095d720b1f360a036bf0c2692ce0193faeafacc4762d5c81f8da5dee3a6R1-R63): Ensures that a location string with exactly two parts where the second part is a known city returns the correct format.
* [`test_non_institution_no_known_city`](diffhunk://#diff-4f7e8095d720b1f360a036bf0c2692ce0193faeafacc4762d5c81f8da5dee3a6R1-R63): Validates that a non-educational address without a known city defaults to "New York".
* [`test_with_coordinates`](diffhunk://#diff-4f7e8095d720b1f360a036bf0c2692ce0193faeafacc4762d5c81f8da5dee3a6R1-R63): Confirms that coordinates inside square brackets are stripped out before processing.
* [`test_educational_institution`](diffhunk://#diff-4f7e8095d720b1f360a036bf0c2692ce0193faeafacc4762d5c81f8da5dee3a6R1-R63): For educational institutions, only the building and city are returned.
* [`test_extra_spaces`](diffhunk://#diff-4f7e8095d720b1f360a036bf0c2692ce0193faeafacc4762d5c81f8da5dee3a6R1-R63): Ensures extra spaces are stripped from the location string.