### PR TITLE
Verified host's -> verified and Host's Listings -> username Listing

### DIFF
--- a/accounts/templates/accounts/public_profile.html
+++ b/accounts/templates/accounts/public_profile.html
@@ -26,7 +26,7 @@
                         {% if is_verified %}
                         <div class="mt-2">
                             <span class="badge bg-pastel-success">
-                                <i class="fas fa-check-circle me-1"></i> Verified Host
+                                <i class="fas fa-check-circle me-1"></i> Verified
                             </span>
                         </div>
                         {% endif %}
@@ -70,7 +70,7 @@
                         <i class="fas fa-car-side text-secondary me-2"></i>
                         <span>
                           <a href="{% url 'user_listings' username=profile_user.username %}" class="host-listings-link">
-                            <strong>Host's Listings</strong>
+                            <strong>{{ profile_user.username }}'s Listings</strong>
                           </a>
                         </span>
                       </div>


### PR DESCRIPTION
This pull request includes updates to the `accounts/templates/accounts/public_profile.html` file to improve the user interface by modifying the text displayed for verified users and host listings.

User interface updates:

* Changed the text "Verified Host" to "Verified" for verified users. (`accounts/templates/accounts/public_profile.html`, [accounts/templates/accounts/public_profile.htmlL29-R29](diffhunk://#diff-68572915ee26203060b0a40db61b98fd8536a1751a61a11866816f7ac6a26b8dL29-R29))
* Updated the host listings link to display the username dynamically, changing "Host's Listings" to "{{ profile_user.username }}'s Listings". (`accounts/templates/accounts/public_profile.html`, [accounts/templates/accounts/public_profile.htmlL73-R73](diffhunk://#diff-68572915ee26203060b0a40db61b98fd8536a1751a61a11866816f7ac6a26b8dL73-R73))