### PR TITLE
Fixed the bug that you can book half hour before now

### DIFF
--- a/booking/views.py
+++ b/booking/views.py
@@ -76,6 +76,31 @@ def available_times(request):
             valid_times.add(current_dt.strftime("%H:%M"))
             current_dt += dt.timedelta(minutes=30)
     times = sorted(valid_times)
+
+    # Filter out past times for today's date
+    today = dt.date.today()
+    if booking_date == today:
+        # Get current time
+        now = dt.datetime.now()
+
+        # Calculate the next available time slot
+        current_minutes = now.minute
+        current_hour = now.hour
+
+        # Round up to the nearest half hour
+        if current_minutes < 30:
+            next_slot_minutes = 30
+            next_slot_hour = current_hour
+        else:
+            next_slot_minutes = 0
+            next_slot_hour = current_hour + 1
+
+        # Format as HH:MM string
+        next_slot_str = f"{next_slot_hour:02d}:{next_slot_minutes:02d}"
+
+        # Filter out times before the next valid slot
+        times = [t for t in times if t >= next_slot_str]
+
     if max_time_str:
         times = [t for t in times if t <= max_time_str]
     if min_time_str:


### PR DESCRIPTION
This pull request updates the `available_times` function in `booking/views.py` to enhance the filtering logic for available booking times. The most significant change ensures that past times are excluded when the booking date is today.

Enhancements to time filtering:

* Added logic to calculate the next available time slot by rounding up to the nearest half-hour when the booking date is today. This ensures that only future time slots are displayed for same-day bookings. (`[booking/views.pyR79-R103](diffhunk://#diff-2d6cc50e9a04c9f50173c2e75c0c6a6d8d94c0abda5e3377099d4e7609d2b1c7R79-R103)`)