### PR TITLE
removing bookmark functionality for not logged in users

### DIFF
--- a/listings/templates/listings/partials/listing_cards.html
+++ b/listings/templates/listings/partials/listing_cards.html
@@ -14,10 +14,13 @@
     <a href="{% url 'report_item' 'listing' listing.id %}" class="report-icon" title="Report this listing">
       <i class="fas fa-flag"></i>
     </a>
+
+    {% if user.is_authenticated %}
     <a href="{% url 'toggle_bookmark' listing.id %}"
        class="bookmark-icon ajax-bookmark {% if listing.id in bookmarked_listings or is_bookmarks_page %}active{% endif %}">
       <i class="{% if listing.id in bookmarked_listings or is_bookmarks_page %}fas{% else %}far{% endif %} fa-bookmark"></i>
     </a>
+    {% endif %}
     {% endif %}
 
     <div class="card-body p-2">


### PR DESCRIPTION
This pull request introduces a conditional check to ensure that the bookmark functionality in the listing cards is only displayed to authenticated users. 

Changes to user interface behavior:

* [`listings/templates/listings/partials/listing_cards.html`](diffhunk://#diff-80399f541d28e3d49a22a043058f39f8c8f2bfd124adccc62def17d03f045156R17-R24): Added a conditional block to wrap the bookmark icon, ensuring it is only shown if the user is authenticated. This prevents unauthenticated users from interacting with the bookmark feature.