### PR TITLE
Develop to Main

### DIFF
--- a/.ebextensions/01_django.config
+++ b/.ebextensions/01_django.config
@@ -20,6 +20,3 @@ container_commands:
   04_collectstatic:
     command: "source /var/app/venv/*/bin/activate && python3 manage.py collectstatic --noinput"
     leader_only: true
-  05_flushdatabase:
-    command: "source /var/app/venv/*/bin/activate && python3 manage.py flush --noinput"
-    leader_only: true


### PR DESCRIPTION
This pull request modifies the Elastic Beanstalk configuration for a Django application by removing a command related to database flushing. 

Configuration updates:

* [`.ebextensions/01_django.config`](diffhunk://#diff-c014b1eaf41f5136520fa109a2e6d1a6097ae49266df2c6b06067a662906679bL23-L25): Removed the `05_flushdatabase` command, which previously flushed the database during deployment. This change ensures that the database is no longer reset during deployment, likely to prevent data loss or unintended side effects.